### PR TITLE
Encourage Solidus Starter Frontend users to subscribe to the Solidus Security mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ In addition, please note that the command will add Solidus Auth Devise
 frontend components to your app. At the moment, you will need to manually
 remove the gem and its frontend components if you don't need them.
 
-Finally, please note that you won't be able to auto-update the storefront code
-with the next versions released since this project's gem will not be present in
-your Gemfile.
+Finally, please note that since the starter frontend is a Rails application
+template, it doesn't have the capability to automatically update your
+storefront code whenever the template is updated.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Finally, please note that since the starter frontend is a Rails application
 template, it doesn't have the capability to automatically update your
 storefront code whenever the template is updated.
 
+## Security updates
+
+To receive security announcements concerning Solidus Starter Frontend, please
+subscribe to the
+[Solidus Security mailing list](https://groups.google.com/forum/#!forum/solidus-security).
+The mailing list is very low traffic, and it receives the public notifications
+the moment the vulnerability is published. For more information, please check out
+https://solidus.io/security.
+
 ## Development
 
 For information about contributing to this project please refer to this

--- a/template.rb
+++ b/template.rb
@@ -5,6 +5,7 @@ def install
   update_asset_files
   require_solidus_starter_frontend_config
   install_rspec
+  print_security_update_message
 end
 
 # Copied from: https://github.com/mattbrictson/rails-template
@@ -88,6 +89,19 @@ end
 
 def install_rspec
   generate 'rspec:install'
+end
+
+def print_security_update_message
+  message = <<~TEXT
+    RECOMMENDED: To receive security announcements concerning Solidus Starter
+    Frontend, please subscribe to the Solidus Security mailing list
+    (https://groups.google.com/forum/#!forum/solidus-security). The mailing
+    list is very low traffic, and it receives the public notifications the
+    moment the vulnerability is published. For more information, please check
+    out https://solidus.io/security.
+  TEXT
+
+  print_wrapped set_color(message.gsub("\n", ' '), :yellow)
 end
 
 install


### PR DESCRIPTION
## Goal

As a Solidus Starter Frontend contributor

I would like the project's documentation to encourage Solidus Starter Frontend users to subscribe to the Solidus Security mailing list

So that our security announcements concerning Solidus Starter Frontend would hopefully reach more users

## Screenshots:

![image](https://user-images.githubusercontent.com/61476/146336966-566d55b2-9b25-4bf3-b01d-e9e5d010b913.png)

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
