### PR TITLE
Remove redundant `skip_before_action :setup_for_current_state` call

### DIFF
--- a/templates/app/controllers/spree/checkout_controller.rb
+++ b/templates/app/controllers/spree/checkout_controller.rb
@@ -21,10 +21,6 @@ module Spree
 
     before_action :setup_for_current_state, only: [:edit, :update]
 
-    # This action builds some associations on the order, ex. addresses, which we
-    # don't need to build or save here.
-    skip_before_action :setup_for_current_state, only: [:registration, :update_registration]
-
     helper 'spree/orders'
 
     rescue_from Spree::Core::GatewayError, with: :rescue_from_spree_gateway_error


### PR DESCRIPTION
## Description

The `skip_before_action :setup_for_current_state, only: [:registration, :update_registration]` call in `Spree::CheckoutController` is redundant because the `before_action :setup_for_current_state, only: [:edit, :update]` before it already skips the `registration` and `update_registration` actions.

## How Has This Been Tested?

* Passed CI.
* Registration in checkout step tested manually.

## Types of changes

- N/A: Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A:  My change requires a change to the documentation.
- N/A:  I have updated the documentation accordingly.
