### PR TITLE
Fix: frontend assets should be added to vendor

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -76,6 +76,15 @@ def copy_solidus_starter_frontend_files
   prepend_file 'config/routes.rb', File.read('tmp/routes.rb')
 
   directory 'spec'
+  directory 'vendor', force: forcefully_replace_any_solidus_frontend_assets?
+end
+
+# In CI, the Rails environment is test. In that Rails environment,
+# `Solidus::InstallGenerator#setup_assets` adds `solidus_frontend` assets to
+# vendor. We'd want to forcefully replace those `solidus_frontend` assets with
+# SolidusStarterFrontend assets in CI.
+def forcefully_replace_any_solidus_frontend_assets?
+  Rails.env.test?
 end
 
 def update_asset_files

--- a/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -1,0 +1,10 @@
+// This is a manifest file that'll be compiled into including all the files listed below.
+// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// be included in the compiled file accessible from http://example.com/assets/application.js
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+//= require jquery
+//= require rails-ujs
+//= require spree/frontend
+//= require_tree .

--- a/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -4,7 +4,6 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require jquery
 //= require rails-ujs
 //= require spree/frontend
 //= require_tree .

--- a/templates/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/templates/vendor/assets/stylesheets/spree/frontend/all.css
@@ -1,0 +1,9 @@
+/*
+ * This is a manifest file that'll automatically include all the stylesheets available in this directory
+ * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
+ * the top of the compiled file, but it's generally better to create a new file per style scope.
+ *
+ *= require spree/frontend
+ *= require_self
+ *= require_tree .
+*/


### PR DESCRIPTION
Goal
----

We want the frontend assets and directories added to a Solidus app because
Solidus extensions assume that these files and directories exist. The Solidus
extensions typically link these pre-existing files to their assets.

Expected behavior
-----------------

Given I have a Solidus app without a frontend

When I apply the SolidusStarterFrontend template to the app

Then I should see the following frontend assets and directories added to the
app:

* `vendor/assets/images/spree/frontend`
* `vendor/assets/javascripts/spree/frontend/all.js`
* `vendor/assets/stylesheets/spree/frontend/all.css`

Current behavior
----------------

SolidusStarterFrontend doesn't add the frontend assets and directories to the
app's vendor directory.

Bug cause
---------

Prior to https://github.com/solidusio/solidus/pull/4251, the Solidus Install
generator was adding the frontend assets during installation even if the app
didn't have `solidus_frontend` in its bundle. With the issue fixed,
SolidusStarterFrontend has to be updated to add these frontend assets by
itself.

## Video explanation

https://www.dropbox.com/s/b673ijy66cafx0n/eng-296-update-solidusstarterfrontend-to-add-all.mkv?dl=0

## Video: demo of bug and fix

https://user-images.githubusercontent.com/61476/155115647-83d08ba6-e942-4961-9f3e-a7434d81074d.mp4

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- N/A: New feature (non-breaking change which adds functionality)
- N/A: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- N/A: My change requires a change to the documentation.
- N/A: I have updated the documentation accordingly.
