### PR TITLE
Fix the CircleCI badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Solidus Starter Frontend
-[![Gem Version](https://badge.fury.io/rb/solidus_starter_frontend.svg)](https://badge.fury.io/rb/solidus_starter_frontend) [![CircleCI](https://circleci.com/gh/nebulab/solidus_starter_frontend.svg?style=shield)](https://circleci.com/gh/nebulab/solidus_starter_frontend)
+[![CircleCI](https://circleci.com/gh/solidusio/solidus_starter_frontend.svg?style=shield)](https://circleci.com/gh/solidusio/solidus_starter_frontend)
 
 `solidus_starter_frontend` is a new starter storefront for [Solidus][solidus].
 


### PR DESCRIPTION
## Description

It was pointing to the temporary repository that we created under the Nebulab org when experimenting with this solution.

On a side note, @gsmendoza do we still need the gem version badge? Is there still any sense in releasing this as a gem? If we don't need that I can remove it in this same PR.

## Motivation and Context

To avoid seeing a broken image in the presentation README:

<img width="478" alt="CleanShot 2022-04-26 at 14 58 47@2x" src="https://user-images.githubusercontent.com/167946/165305182-4394c8d0-0388-48c2-b9bc-cf03dda04353.png">




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
