### PR TITLE
Fix noise and deprecation warnings when running specs

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -57,7 +57,7 @@ end
 def add_spec_gems
   gem_group :development, :test do
     gem 'rspec-rails'
-    gem 'apparition', '~> 0.6.0'
+    gem 'apparition', '~> 0.6.0', github: 'twalpole/apparition'
     gem 'rails-controller-testing', '~> 1.0.5'
     gem 'rspec-activemodel-mocks', '~> 1.1.0'
     gem 'solidus_dev_support', '~> 2.5'

--- a/templates/app/views/spree/products/_product_header.html.erb
+++ b/templates/app/views/spree/products/_product_header.html.erb
@@ -9,7 +9,7 @@
         :span,
         display_price(product),
         itemprop: 'price',
-        content: product.price_for(current_pricing_options).to_d,
+        content: product.price_for_options(current_pricing_options)&.money.to_d,
         data: { js: 'price' }
       ) %>
 

--- a/templates/app/views/spree/products/_product_variants.html.erb
+++ b/templates/app/views/spree/products/_product_variants.html.erb
@@ -19,7 +19,7 @@
             "data-js_price" => variant.price_for_options(current_pricing_options)&.money.to_s,
             "data-option-value-ids" => sorted_option_values(variant).to_json,
             "data-target" => "variantOptions",
-            "data-price" => variant.price_for(current_pricing_options).to_html
+            "data-price" => variant.price_for(current_pricing_options)&.to_html
           ) %>
 
           <%= label_tag "variant_id_#{ variant.id }" do %>

--- a/templates/app/views/spree/products/_product_variants.html.erb
+++ b/templates/app/views/spree/products/_product_variants.html.erb
@@ -19,7 +19,7 @@
             "data-js_price" => variant.price_for_options(current_pricing_options)&.money.to_s,
             "data-option-value-ids" => sorted_option_values(variant).to_json,
             "data-target" => "variantOptions",
-            "data-price" => variant.price_for(current_pricing_options)&.to_html
+            "data-price" => variant.price_for_options(current_pricing_options)&.money&.to_html
           ) %>
 
           <%= label_tag "variant_id_#{ variant.id }" do %>

--- a/templates/spec/components/breadcrumbs_component_spec.rb
+++ b/templates/spec/components/breadcrumbs_component_spec.rb
@@ -8,27 +8,23 @@ require 'spree/taxon'
 RSpec.describe BreadcrumbsComponent, type: :component do
   let(:request_url) { '/' }
 
-  subject(:component) do
-    render_inline(described_class.new(taxon))
-
-    rendered_component
-  end
-
   let(:breadcrumb_items) do
-    Capybara.string(component).all('a[itemprop=item]').map(&:text)
+    page.all('a[itemprop=item]').map(&:text)
   end
 
-  before  do
-    allow(self.request).to receive(:path).and_return(request_url)
-  end
+  context 'when rendered' do
+    before do
+      allow(self.request).to receive(:path).and_return(request_url)
 
-  describe '#call' do
-    let(:taxon) { nil }
+      render_inline(described_class.new(taxon))
+    end
 
     context 'when the taxon is nil' do
       let(:taxon) { nil }
 
-      it { is_expected.to be_blank }
+      it 'does not render any breadcrumb items' do
+        expect(breadcrumb_items.size).to eq(0)
+      end
     end
 
     context 'when the taxon is present' do
@@ -39,7 +35,9 @@ RSpec.describe BreadcrumbsComponent, type: :component do
       context 'when the current page is the root page' do
         let(:request_url) { '/' }
 
-        it { is_expected.to be_blank }
+        it 'does not render any breadcrumb items' do
+          expect(breadcrumb_items.size).to eq(0)
+        end
       end
 
       context 'when the current page is not the root page' do

--- a/templates/spec/components/filter_component_spec.rb
+++ b/templates/spec/components/filter_component_spec.rb
@@ -1,23 +1,21 @@
 require "solidus_starter_frontend_helper"
 
 RSpec.describe FilterComponent, type: :component do
-  describe '#call' do
-    let(:filter) { Spree::Core::ProductFilters.price_filter }
-    let(:search_params) { {} }
+  let(:filter) { Spree::Core::ProductFilters.price_filter }
+  let(:search_params) { {} }
 
-    let(:component) do
+  let(:inputs) do
+    page.all('input')
+  end
+
+  context 'when rendered' do
+    before do
       render_inline(described_class.new(filter: filter, search_params: search_params))
-
-      Capybara.string(rendered_component)
-    end
-
-    let(:input_ids) do
-      component.all('input').map { |input| input[:id] }
     end
 
     it 'renders a list of checkboxes for the filter labels' do
-      expect(input_ids).to_not be_empty
-      expect(input_ids.first).to eq('Price_Range_Under__10.00')
+      expect(inputs).to_not be_empty
+      expect(inputs.first[:id]).to eq('Price_Range_Under__10.00')
     end
 
     context 'when a filter list item was checked' do
@@ -26,7 +24,7 @@ RSpec.describe FilterComponent, type: :component do
       end
 
       it 'renders as checked' do
-        expect(component.first('input')['checked']).to be_truthy
+        expect(inputs.first['checked']).to be_truthy
       end
     end
 
@@ -34,7 +32,7 @@ RSpec.describe FilterComponent, type: :component do
       let(:search_params) { { } }
 
       it 'renders as unchecked' do
-        expect(component.first('input')['checked']).to be_falsey
+        expect(inputs.first['checked']).to be_falsey
       end
     end
   end

--- a/templates/spec/components/image_component_spec.rb
+++ b/templates/spec/components/image_component_spec.rb
@@ -1,87 +1,62 @@
 require "solidus_starter_frontend_helper"
 
 RSpec.describe ImageComponent, type: :component do
-  def normalize_html(html)
-    html.gsub(/\n */, '')
-  end
+  let(:page_image) { page.find('img') }
 
-  let(:normalized_expected_match) do
-    Regexp.new(normalize_html(expected_match))
-  end
-
-  let(:component) do
-    render_inline(described_class.new(arguments))
-
-    rendered_component
-  end
-
-  subject(:normalized_component) { normalize_html(component) }
-
-  context 'when no arguments are provided' do
-    let(:arguments) { { } }
-
-    it 'renders a placeholder' do
-      expect(normalized_component).to eq(%Q{<div class="image-placeholder mini"></div>})
+  context 'when rendered' do
+    before do
+      render_inline(described_class.new(arguments))
     end
-  end
 
-  context 'when an image is provided' do
-    let(:alt) { 'some-alt' }
-    let(:image) { build(:image, alt: alt) }
-    let(:arguments) { { image: image } }
+    context 'when no arguments are provided' do
+      let(:arguments) { { } }
 
-    context 'when the image has an alt' do
+      it 'renders a placeholder' do
+        expect(page).to have_selector('div.image-placeholder.mini')
+      end
+    end
+
+    context 'when an image is provided' do
       let(:alt) { 'some-alt' }
+      let(:image) { build(:image, alt: alt) }
+      let(:arguments) { { image: image } }
 
-      let(:expected_match) do
-        %Q{
-          <img alt="some-alt" src="/assets/noimage/mini-.*.png" />
+      context 'when the image has an alt' do
+        let(:alt) { 'some-alt' }
+
+        it 'renders the image' do
+          expect(page_image['alt']).to eq(alt)
+          expect(page_image['src']).to match(%r{/assets/noimage/mini-.*.png})
+        end
+      end
+
+      context 'when the image does not have an alt' do
+        let(:alt) { nil }
+
+        it 'renders the image' do
+          expect(page_image['alt']).to be_nil
+          expect(page_image['src']).to match(%r{/assets/noimage/mini-.*.png})
+        end
+      end
+    end
+
+    context 'when all the required arguments are provided' do
+      let(:arguments) do
+        {
+          image: build(:image),
+          size: :small,
+          itemprop: 'some-itemprop',
+          classes: ['some-class'],
+          data: { key: 'value' },
         }
       end
 
-      let(:normalized_expected_match) do
-        Regexp.new(normalize_html(expected_match))
-      end
-
       it 'renders the image' do
-        expect(normalized_component).to match(normalized_expected_match)
+        expect(page_image['class']).to eq('some-class')
+        expect(page_image['itemprop']).to eq('some-itemprop')
+        expect(page_image['data-key']).to eq('value')
+        expect(page_image['src']).to match(%r{/assets/noimage/small-.*.png})
       end
-    end
-
-    context 'when the image does not have an alt' do
-      let(:alt) { nil }
-
-      let(:expected_match) do
-        %Q{
-          <img src="/assets/noimage/mini-.*.png" />
-        }
-      end
-
-      it 'renders the image' do
-        expect(normalized_component).to match(normalized_expected_match)
-      end
-    end
-  end
-
-  context 'when all the required arguments are provided' do
-    let(:arguments) do
-      {
-        image: build(:image),
-        size: :small,
-        itemprop: 'some-itemprop',
-        classes: ['some-class'],
-        data: { key: 'value' },
-      }
-    end
-
-    let(:expected_match) do
-      %Q{
-        <img class="some-class" itemprop="some-itemprop" data-key="value" src="/assets/noimage/small-.*.png" />
-      }
-    end
-
-    it 'renders the image' do
-      expect(normalized_component).to match(normalized_expected_match)
     end
   end
 end

--- a/templates/spec/components/link_to_cart_component_spec.rb
+++ b/templates/spec/components/link_to_cart_component_spec.rb
@@ -7,22 +7,14 @@ RSpec.describe LinkToCartComponent, type: :component do
     described_class.new(text)
   end
 
-  let(:rendered_link_to_cart_component) do
-    render_inline(link_to_cart_component)
+  let(:current_order) { nil }
 
-    rendered_component
-  end
-
-  let(:rendered_link_to_cart_component_node) do
-    Capybara.string(rendered_link_to_cart_component)
-  end
-
-  describe '#call' do
-    let(:current_order) { nil }
-
+  context 'when rendered' do
     before do
       expect(link_to_cart_component)
         .to receive(:current_order).at_least(:once).and_return(current_order)
+
+      render_inline(link_to_cart_component)
     end
 
     describe 'concerning current_order' do
@@ -30,7 +22,7 @@ RSpec.describe LinkToCartComponent, type: :component do
         let(:current_order) { nil }
 
         it 'renders an empty cart' do
-          link = rendered_link_to_cart_component_node.find('a.cart-info')
+          link = page.find('a.cart-info')
 
           aggregate_failures do
             expect(link).to_not be_nil
@@ -47,7 +39,7 @@ RSpec.describe LinkToCartComponent, type: :component do
           let(:line_items_count) { 0 }
 
           it 'renders an empty cart' do
-            expect(rendered_link_to_cart_component_node.find('a.cart-info').text).to be_empty
+            expect(page.find('a.cart-info').text).to be_empty
           end
         end
 
@@ -55,7 +47,7 @@ RSpec.describe LinkToCartComponent, type: :component do
           let(:line_items_count) { 1 }
 
           it 'renders a cart with its item count' do
-            expect(rendered_link_to_cart_component_node.find('a.cart-info.full .link-text'))
+            expect(page.find('a.cart-info.full .link-text'))
               .to have_content(line_items_count)
           end
         end

--- a/templates/spec/components/taxons_tree_component_spec.rb
+++ b/templates/spec/components/taxons_tree_component_spec.rb
@@ -2,52 +2,50 @@ require "solidus_starter_frontend_helper"
 require 'spree/taxon'
 
 RSpec.describe TaxonsTreeComponent, type: :component do
-  describe '#call' do
-    let(:taxon_without_descendants) { create(:taxon, children: []) }
+  let(:taxon_without_descendants) { create(:taxon, children: []) }
 
-    let(:taxon_with_descendants) do
-      root = create(:taxon)
+  let(:taxon_with_descendants) do
+    root = create(:taxon)
 
-      children = [
-        create(:taxon, name: 'child 1', parent: root),
-        create(:taxon, name: 'child 2', parent: root)
-      ]
+    children = [
+      create(:taxon, name: 'child 1', parent: root),
+      create(:taxon, name: 'child 2', parent: root)
+    ]
 
-      # child 1 grandchild
-      create(:taxon, name: 'grandchild 1', parent: children[0])
+    # child 1 grandchild
+    create(:taxon, name: 'grandchild 1', parent: children[0])
 
-      root
-    end
+    root
+  end
 
-    let(:title) { 'some_title' }
-    let(:root_taxon) { taxon_with_descendants }
-    let(:current_taxon) { nil }
-    let(:max_level) { 1 }
-    let(:base_class) { 'some_base_class' }
+  let(:title) { 'some_title' }
+  let(:root_taxon) { taxon_with_descendants }
+  let(:current_taxon) { nil }
+  let(:max_level) { 1 }
+  let(:base_class) { 'some_base_class' }
 
-    let(:local_assigns) do
-      {
-        title: title,
-        root_taxon: root_taxon,
-        current_taxon: current_taxon,
-        max_level: max_level,
-        base_class: base_class
-      }
-    end
+  let(:local_assigns) do
+    {
+      title: title,
+      root_taxon: root_taxon,
+      current_taxon: current_taxon,
+      max_level: max_level,
+      base_class: base_class
+    }
+  end
 
-    subject(:component) do
+  context 'when rendered' do
+    before do
       render_inline(described_class.new(local_assigns))
-
-      rendered_component
     end
-
-    let(:component_node) { Capybara.string(component) }
 
     describe 'concerning max_level and root_taxon' do
       context 'when the max level is less than 1' do
         let(:max_level) { 0 }
 
-        it { is_expected.to be_blank }
+        it 'does not render any items' do
+          expect(page.all('li')).to be_empty
+        end
       end
 
       context 'when the max level is 1' do
@@ -56,14 +54,16 @@ RSpec.describe TaxonsTreeComponent, type: :component do
         context 'when the root taxon has no descendants' do
           let(:root_taxon) { taxon_without_descendants }
 
-          it { is_expected.to be_blank }
+          it 'does not render any items' do
+            expect(page.all('li')).to be_empty
+          end
         end
 
         context 'when the root taxon has descendants' do
           let(:root_taxon) { taxon_with_descendants }
 
           it "renders a list of the root taxon's children" do
-            expect(component_node.all('li').map(&:text)).to match(['child 1', 'child 2'])
+            expect(page.all('li').map(&:text)).to match(['child 1', 'child 2'])
           end
         end
       end
@@ -74,7 +74,9 @@ RSpec.describe TaxonsTreeComponent, type: :component do
         context 'when the root taxon has no descendants' do
           let(:root_taxon) { taxon_without_descendants }
 
-          it { is_expected.to be_blank }
+          it 'does not render any items' do
+            expect(page.all('li')).to be_empty
+          end
         end
 
         context 'when the root taxon has descendants' do
@@ -82,7 +84,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
 
           it "renders a list of the root taxon's descendants" do
             # child 1's text includes the text of the grandchild 1.
-            expect(component_node.all('li').map(&:text)).to match(['child 1grandchild 1', 'grandchild 1', 'child 2'])
+            expect(page.all('li').map(&:text)).to match(['child 1grandchild 1', 'grandchild 1', 'child 2'])
           end
         end
       end
@@ -93,7 +95,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
         let(:current_taxon) { nil }
 
         it 'does not mark any taxon as "current"' do
-          expect(component_node).to have_no_css('li.current')
+          expect(page).to have_no_css('li.current')
         end
       end
 
@@ -102,7 +104,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
           let(:current_taxon) { root_taxon.children.first }
 
           it 'marks the current taxon as "current"' do
-            expect(component_node.find('li.current')).to have_text('child 1')
+            expect(page.find('li.current')).to have_text('child 1')
           end
         end
 
@@ -110,7 +112,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
           let(:current_taxon) { create(:taxon) }
 
           it 'does not mark any taxon as "current"' do
-            expect(component_node).to have_no_css('li.current')
+            expect(page).to have_no_css('li.current')
           end
         end
       end
@@ -122,8 +124,8 @@ RSpec.describe TaxonsTreeComponent, type: :component do
 
       it 'uses the base class as prefix for the list and title classes' do
         aggregate_failures do
-          expect(component_node).to have_css('h6.some_base_class__title')
-          expect(component_node).to have_css('ul.some_base_class__list')
+          expect(page).to have_css('h6.some_base_class__title')
+          expect(page).to have_css('ul.some_base_class__list')
         end
       end
     end
@@ -135,7 +137,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
         let(:title) { 'some_title' }
 
         it 'renders the title' do
-          expect(component_node).to have_css('h6.some_base_class__title')
+          expect(page).to have_css('h6.some_base_class__title')
         end
       end
 
@@ -143,7 +145,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
         let(:title) { nil }
 
         it 'does not render the title' do
-          expect(component_node).to have_no_css('h6.some_base_class__title')
+          expect(page).to have_no_css('h6.some_base_class__title')
         end
       end
     end


### PR DESCRIPTION
Fixes three messages that appear when running the specs:

* Unexpected inner loop exception: unknown keyword: type.
* `price_for` is deprecated and will be removed.
* `rendered_component` is deprecated and will be removed in v3.0.0.