### PR TITLE
Use `spree_current_user` instead of `try_spree_current_user`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - setup
       - test-branch:
-          branch: v3.1.5
+          branch: v3.1
           rails_version: "~> 6.1"
       - solidusio_extensions/store-test-results
   run-specs-with-mysql:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - setup
       - test-branch:
-          branch: v3.1.5
+          branch: v3.1
           rails_version: "~> 6.1"
       - solidusio_extensions/store-test-results
   run-specs-with-postgres-and-solidus-latest:

--- a/templates/app/controllers/spree/checkout_controller.rb
+++ b/templates/app/controllers/spree/checkout_controller.rb
@@ -217,8 +217,8 @@ module Spree
         end
       end
 
-      if try_spree_current_user && try_spree_current_user.respond_to?(:wallet)
-        @wallet_payment_sources = try_spree_current_user.wallet.wallet_payment_sources
+      if spree_current_user && spree_current_user.respond_to?(:wallet)
+        @wallet_payment_sources = spree_current_user.wallet.wallet_payment_sources
         @default_wallet_payment_source = @wallet_payment_sources.detect(&:default) ||
                                          @wallet_payment_sources.first
       end

--- a/templates/app/controllers/spree/products_controller.rb
+++ b/templates/app/controllers/spree/products_controller.rb
@@ -36,7 +36,7 @@ module Spree
     end
 
     def load_product
-      if try_spree_current_user.try(:has_spree_role?, "admin")
+      if spree_current_user.try(:has_spree_role?, "admin")
         @products = Spree::Product.with_discarded
       else
         @products = Spree::Product.available

--- a/templates/app/views/spree/checkout/steps/_address_step.html.erb
+++ b/templates/app/views/spree/checkout/steps/_address_step.html.erb
@@ -43,12 +43,12 @@
       name: :commit
     ) %>
 
-    <% if try_spree_current_user %>
+    <% if spree_current_user %>
       <%= label_tag 'save-user-address', class: 'checkbox-input' do %>
         <%= check_box_tag(
           :save_user_address,
           1,
-          try_spree_current_user.respond_to?(:persist_order_address),
+          spree_current_user.respond_to?(:persist_order_address),
           id: 'save-user-address'
         ) %>
         <%= I18n.t("spree.save_my_address") %>

--- a/templates/app/views/spree/orders/show.html.erb
+++ b/templates/app/views/spree/orders/show.html.erb
@@ -21,7 +21,7 @@
     <%= link_to t('spree.back_to_store'), spree.root_path, class: "button" %>
 
     <% unless order_just_completed?(@order) %>
-      <% if try_spree_current_user && respond_to?(:account_path) %>
+      <% if spree_current_user && respond_to?(:account_path) %>
         <%= link_to t('spree.my_account'), spree.account_path, class: "button" %>
       <% end %>
     <% end %>

--- a/templates/config/initializers/solidus_auth_devise_unauthorized_redirect.rb
+++ b/templates/config/initializers/solidus_auth_devise_unauthorized_redirect.rb
@@ -1,6 +1,6 @@
 Rails.application.config.to_prepare do
   Spree::BaseController.unauthorized_redirect = -> do
-    if try_spree_current_user
+    if spree_current_user
       flash[:error] = I18n.t('spree.authorization_failure')
 
       if Spree::Auth::Engine.redirect_back_on_unauthorized?

--- a/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
+++ b/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'Checkout confirm page submission', type: :system do
       order_stock_item.update! backorderable: false
       order_stock_item.set_count_on_hand(1)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-      allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
     end
 
     context 'when there are not other backorderable stock locations' do

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
 
       before do
         allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-        allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-        allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+        allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
         add_mug_to_cart
         click_button "Checkout"
@@ -172,8 +172,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
 
           # Simulate user login
           Spree::Order.last.associate_user!(user)
-          allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-          allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+          allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+          allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
           # Simulate redirect back to address after login
           visit spree.checkout_state_path(:address)
@@ -222,7 +222,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     end
 
     it "does not allow successful order submission" do
@@ -244,7 +244,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     end
 
     it "redirects to payment page", inaccessible: true do
@@ -275,7 +275,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
 
     before(:each) do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(skip_state_validation?: true)
     end
 
@@ -319,7 +319,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: order.user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: order.user)
 
       visit spree.checkout_state_path(:payment)
     end
@@ -351,8 +351,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-      allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
       visit spree.checkout_state_path(:payment)
     end
@@ -569,8 +569,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       before do
         user = create(:user)
         Spree::Order.last.update_column :user_id, user.id
-        allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
-        allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+        allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
         click_button "Checkout"
       end
 
@@ -586,8 +586,8 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
 
     before(:each) do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-      allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
       visit spree.checkout_state_path(:delivery)
       click_button "Save and Continue"

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       click_on "Place Order"
 
       order = Spree::Order.last
-      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token))
+      expect(page).to have_current_path(spree.order_path(order))
       expect(page).to have_content("Ending in #{credit_card.last_digits}")
     end
 
@@ -376,7 +376,7 @@ RSpec.describe 'Checkout', type: :system, inaccessible: true do
       click_on "Place Order"
 
       order = Spree::Order.last
-      expect(page).to have_current_path(spree.token_order_path(order, order.guest_token))
+      expect(page).to have_current_path(spree.order_path(order))
       expect(page).to have_content('Ending in 1111')
     end
   end

--- a/templates/spec/system/checkout_unshippable_spec.rb
+++ b/templates/spec/system/checkout_unshippable_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'checkout with unshippable items', type: :system, inaccessible: t
     order.recalculate
 
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-    allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(skip_state_validation?: true)
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(ensure_sufficient_stock_lines: true)
   end

--- a/templates/spec/system/coupon_code_spec.rb
+++ b/templates/spec/system/coupon_code_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe 'Coupon code promotions', type: :system, js: true do
         let!(:user) { create(:user, bill_address: create(:address), ship_address: create(:address)) }
 
         before do
-          allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-          allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
-          allow_any_instance_of(Spree::CouponCodesController).to receive_messages(try_spree_current_user: user)
+          allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+          allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
+          allow_any_instance_of(Spree::CouponCodesController).to receive_messages(spree_current_user: user)
         end
 
         context 'with saved credit card' do

--- a/templates/spec/system/order_spec.rb
+++ b/templates/spec/system/order_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'orders', type: :system do
 
   before do
     order.update_attribute(:user_id, user.id)
-    allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+    allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
   end
 
   it "can visit an order" do


### PR DESCRIPTION
## Description

This fixes SolidusStarterFrontend after the changes in
https://github.com/solidusio/solidus/pull/3923 (Deprecate
`try_spree_current_user`).

The change reveals some incorrect expections in the checkout specs. Please see the commit messages for details.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- N/A - New feature (non-breaking change which adds functionality)
- N/A - Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- N/A - My change requires a change to the documentation.
- N/A - I have updated the documentation accordingly.
