### PR TITLE
Fix view_components deprecation warning in solidus_starter_frontend

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -51,7 +51,7 @@ def add_solidus_starter_frontend_dependencies
   gem 'canonical-rails'
   gem 'solidus_support'
   gem 'truncate_html'
-  gem 'view_component', require: 'view_component/engine'
+  gem 'view_component', '~> 2.46'
 end
 
 def add_spec_gems


### PR DESCRIPTION
Fixes the following warning when loading view_component:

```
DEPRECATION WARNING: This manually engine loading is deprecated and will
be removed in v3.0.0. Remove `require "view_component/engine"`. (called
from <top (required)> at
/home/gsmendoza/repos/solidusio/solidus_starter_frontend/sandbox/config/application.rb:19)
```

See https://github.com/github/view_component/releases/tag/v2.46.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ~Bug fix (non-breaking change which fixes an issue)~
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
