### PR TITLE
Point solidus_compare to solidus_frontend repo

### DIFF
--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -101,7 +101,9 @@ end
 
 def solidus_compare
   report = @config['project_paths'].map do |path|
-    remote_source = "remotes/#{@config['source_name']}/#{@config['source_branch']}"
+    remote_source =
+      @config['source_commit'] || "remotes/#{@config['source_name']}/#{@config['source_branch']}"
+
     remote_path = "#{@config['source_base_path']}#{path}"
     result = `git diff "#{remote_source}" -- "#{remote_path}" "#{@config['local_base_path']}#{path}"`
     puts("error with git diff #{path}") & exit if $?.exitstatus != 0

--- a/bin/solidus_compare
+++ b/bin/solidus_compare
@@ -92,10 +92,10 @@ def load_config
   @config ||= {}
   @config['ignore'] ||= []
   @config['project_paths'] ||= []
-  @config['source_repo'] ||= 'https://github.com/solidusio/solidus.git'
-  @config['source_name'] ||= 'solidus'
+  @config['source_repo'] ||= 'https://github.com/solidusio/solidus_frontend.git'
+  @config['source_name'] ||= 'solidus_frontend'
   @config['source_branch'] ||= 'master'
-  @config['source_base_path'] ||= 'frontend/'
+  @config['source_base_path'] ||= './'
   @config['local_base_path'] ||= 'templates/'
 end
 

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -2,14 +2,15 @@
 project_paths:
 - app/controllers
 - app/helpers
-source_repo: https://github.com/solidusio/solidus.git
-source_commit: 935c8aeaaa2e427b6ea8f53d220b99aef2d98bf3
-source_base_path: frontend/
+source_repo: https://github.com/solidusio/solidus_frontend.git
+source_name: solidus_frontend
+source_branch: master
+source_base_path: "./"
 local_base_path: templates/
 ignore:
 - path: app/controllers
   diffs:
-  - file: frontend/app/controllers/spree/checkout_controller.rb
+  - file: app/controllers/spree/checkout_controller.rb
     skip: true
   - file: templates/app/controllers/spree/user_confirmations_controller.rb
     skip: true
@@ -23,18 +24,18 @@ ignore:
     skip: true
   - file: templates/app/controllers/concerns/solidus_starter_frontend/taxonomies.rb
     skip: true
-  - hash: 2640709950
-    file: frontend/app/controllers/spree/coupon_codes_controller.rb
-  - hash: 3287963782
-    file: frontend/app/controllers/spree/home_controller.rb
-  - hash: 219962801
-    file: frontend/app/controllers/spree/products_controller.rb
-  - hash: 2948126606
-    file: frontend/app/controllers/spree/store_controller.rb
-  - hash: 3344682350
-    file: frontend/app/controllers/spree/taxons_controller.rb
-  - hash: 3587971972
-    file: frontend/app/controllers/spree/content_controller.rb
+  - hash: 3258206090
+    file: app/controllers/spree/coupon_codes_controller.rb
+  - hash: 270376296
+    file: app/controllers/spree/home_controller.rb
+  - hash: 3266230916
+    file: app/controllers/spree/products_controller.rb
+  - hash: 2687797976
+    file: app/controllers/spree/store_controller.rb
+  - hash: 3411057011
+    file: app/controllers/spree/taxons_controller.rb
+  - hash: 1926803060
+    file: app/controllers/spree/content_controller.rb
 - path: app/helpers
   diffs:
   - hash: 1254388106

--- a/config/solidus_compare.yml
+++ b/config/solidus_compare.yml
@@ -3,8 +3,7 @@ project_paths:
 - app/controllers
 - app/helpers
 source_repo: https://github.com/solidusio/solidus.git
-source_name: solidus
-source_branch: master
+source_commit: 935c8aeaaa2e427b6ea8f53d220b99aef2d98bf3
 source_base_path: frontend/
 local_base_path: templates/
 ignore:


### PR DESCRIPTION
## Summary

* I've verified that SolidusStarterFrontend matched Solidus's frontend directory right before the directory was deleted. I did this by comparing SolidusStarterFrontend to Solidus at commit [935c8aeaaa2e427b6ea8f53d220b99aef2d98bf3](https://github.com/solidusio/solidus/commit/935c8aeaaa2e427b6ea8f53d220b99aef2d98bf3).
* https://github.com/solidusio/solidus_frontend/commit/2446d3bf420cfdf9aa94c80de4801ca0d476cdbb also ensures that SolidusFrontend matched Solidus's frontend directory. This means SolidusStarterFrontend matches SolidusFrontend as well.
* Pointing `solidus_compare` to the SolidusFrontend repo caused the diff hashes in the `solidus_compare`'s config to change. I think the hash changes were caused by the changes in the source directory values of `solidus_compare`'s config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
