### PR TITLE
Utilize Devise Location helpers

### DIFF
--- a/templates/app/controllers/spree/checkout_controller.rb
+++ b/templates/app/controllers/spree/checkout_controller.rb
@@ -259,7 +259,6 @@ module Spree
     def check_registration
       return unless registration_required?
 
-      store_location
       redirect_to spree.checkout_registration_path
     end
 

--- a/templates/app/controllers/spree/user_sessions_controller.rb
+++ b/templates/app/controllers/spree/user_sessions_controller.rb
@@ -20,7 +20,7 @@ class Spree::UserSessionsController < Devise::SessionsController
       respond_to do |format|
         format.html do
           flash[:success] = I18n.t('spree.logged_in_succesfully')
-          redirect_back_or_default(after_sign_in_path_for(spree_current_user))
+          redirect_to stored_spree_user_location_or(spree.root_path)
         end
         format.js { render success_json }
       end
@@ -48,11 +48,6 @@ class Spree::UserSessionsController < Devise::SessionsController
 
   def accurate_title
     I18n.t('spree.login')
-  end
-
-  def redirect_back_or_default(default)
-    redirect_to(session["spree_user_return_to"] || default)
-    session["spree_user_return_to"] = nil
   end
 
   def success_json

--- a/templates/app/controllers/spree/users_controller.rb
+++ b/templates/app/controllers/spree/users_controller.rb
@@ -19,7 +19,7 @@ class Spree::UsersController < Spree::StoreController
         session[:guest_token] = nil
       end
 
-      redirect_back_or_default(root_url)
+      redirect_to stored_spree_user_location_or(spree.root_path)
     else
       render :new
     end

--- a/templates/config/initializers/solidus_auth_devise_unauthorized_redirect.rb
+++ b/templates/config/initializers/solidus_auth_devise_unauthorized_redirect.rb
@@ -9,7 +9,6 @@ Rails.application.config.to_prepare do
         redirect_to spree.unauthorized_path
       end
     else
-      store_location
 
       if Spree::Auth::Engine.redirect_back_on_unauthorized?
         redirect_back(fallback_location: spree.login_path)


### PR DESCRIPTION
## Description
Removes #redirect_back_or_default in favor of solidus_auth_devise helper methods

## Motivation and Context
The method #redirect_back_or_default and the class user_last_url_storer will be deprecated in Solidus https://github.com/solidusio/solidus/pull/4533 which would break the current build without these changes. SolidusAuthDevise has similar a helper method to #redirect_back_or_default, #stored_spree_user_location_or which was introduced in [solidus_auth_devise PR228](https://github.com/solidusio/solidus_auth_devise/pull/228) and will be utilized instead.

## How Has This Been Tested?
The current test suite covers the changes made in the PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
