### PR TITLE
Add script and template to quickly update the sandbox

### DIFF
--- a/bin/quick_update_sandbox
+++ b/bin/quick_update_sandbox
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+extension_name="solidus_starter_frontend"
+
+sandbox_name='sandbox'
+sandbox_path="./${sandbox_name}"
+
+cd "${sandbox_path}"
+
+LOCATION='../template.rb' QUICK_UPDATE=1 bundle exec rails app:template
+
+echo
+echo "🚀 Sandbox app successfully updated for ${extension_name}!"

--- a/template.rb
+++ b/template.rb
@@ -1,10 +1,13 @@
 def install
   add_template_repository_to_source_path
-  install_gems
+  install_gems unless quick_update?
   copy_solidus_starter_frontend_files
-  update_asset_files
-  install_rspec
-  print_security_update_message
+
+  unless quick_update?
+    update_asset_files
+    install_rspec
+    print_security_update_message
+  end
 end
 
 # Copied from: https://github.com/mattbrictson/rails-template
@@ -69,6 +72,7 @@ def copy_solidus_starter_frontend_files
   copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'
   copy_file 'config/initializers/canonical_rails.rb'
 
+  copy_file 'config/solidus_default_routes.rb', 'config/routes.rb' if quick_update?
   copy_file 'config/routes.rb', 'tmp/routes.rb'
   prepend_file 'config/routes.rb', File.read('tmp/routes.rb')
 
@@ -104,6 +108,10 @@ def print_security_update_message
   TEXT
 
   print_wrapped set_color(message.gsub("\n", ' '), :yellow)
+end
+
+def quick_update?
+  ENV.fetch('QUICK_UPDATE', nil)
 end
 
 install

--- a/templates/config/solidus_default_routes.rb
+++ b/templates/config/solidus_default_routes.rb
@@ -1,0 +1,16 @@
+# This is a copy of the default routes file that comes with a fresh Solidus
+# installation. This is used when regenerating the `routes.rb` file when
+# QUICK_UPDATE on `template.rb` is enabled`.
+Rails.application.routes.draw do
+  # This line mounts Solidus's routes at the root of your application.
+  # This means, any requests to URLs such as /products, will go to Spree::ProductsController.
+  # If you would like to change where this engine is mounted, simply change the :at option to something different.
+  #
+  # We ask that you don't use the :as option here, as Solidus relies on it being the default of "spree"
+  mount Spree::Core::Engine, at: '/'
+
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  # Defines the root path route ("/")
+  # root "articles#index"
+end


### PR DESCRIPTION
## Goal

As a maintainer of SolidusStarterFrontend, I want to be able to quickly update the sandbox whenever I make changes to the templates. Currently, `bin/sandbox` takes more than 1.5 minutes to run on my machine.

Proposed solution
-----------------

-   Add a `bin/quick_update_sandbox` script that only updates the sandbox; it doesn't regenerate the sandbox Solidus app from scratch.

-   Add a `QUICK_UPDATE` environment variable configuration to the `template.rb`. Skip slow actions in `template.rb` if `QUICK_UPDATE` is enabled.

-   Let the `bin/quick_update_sandbox` script call `template.rb` with `QUICK_UPDATE` enabled.

Actions that can be skipped
---------------------------

-   Generation of new Solidus app
-   Installation of SolidusStarterFrontend gem dependencies

Expected quick update limitations
---------------------------------

-   When `template.rb` copies files from `templates` to the sandbox, it won't be able to delete files in sandbox that have been deleted or moved in the `templates` directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
~- [ ] Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
