### PR TITLE
Add solidus_auth_devise if missing in the target app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We aim to deliver:
 - a reusable component based architecture
 - simple SASS styling strictly based on BEM
 - the elimination of jQuery as a dependency by rewriting frontend functionality
-in vanilla JavaScript
+  in vanilla JavaScript
 
 All of this while keeping and improving on the functionality of the current
 [Solidus][solidus] frontend subcomponent.
@@ -33,16 +33,14 @@ Just run:
 rails new store --skip-javascript
 cd store
 bundle add solidus
-bin/rails generate solidus:install --auto-accept
+bin/rails generate solidus:install --frontend=soldius_starter_frontend
 ```
 
 That will create a new Solidus application with SolidusStarterFrontend as its
 storefront.
 
-Please note that `--auto-accept` will add
-[Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
-to your application. SolidusStarterFrontend requires the application to include
-the gem.
+Please note that [Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
+will also be added to your application as it's required by SolidusStarterFrontend.
 
 ### For existing stores
 
@@ -68,10 +66,11 @@ You'll also need to make sure that
 [Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
 is installed in your application.
 
-You can then copy the starter frontend files to your project:
+Then you can run the app template with this command:
 
 ```shell
-$ LOCATION="https://raw.githubusercontent.com/solidusio/solidus_starter_frontend/main/template.rb" bin/rails app:template
+$ bin/rails app:template LOCATION="https://github.com/solidusio/solidus_starter_frontend/raw/master/template.rb"
+$ bin/rails db:migrate
 ```
 
 ## Considerations

--- a/template.rb
+++ b/template.rb
@@ -18,18 +18,18 @@ def add_template_repository_to_source_path
 
     tempdir = Dir.mktmpdir("solidus_starter_frontend-")
     repo_dir = tempdir
-
+    url_path = URI.parse(__FILE__).path
+    branch = url_path[%r{solidus_starter_frontend/(raw/)?(.+?)/template.rb}, 2]
+    owner = url_path[%r{/([^/]+)/solidus_starter_frontend/}, 1]
     at_exit { FileUtils.remove_entry(tempdir) }
 
     git clone: [
       "--quiet",
-      "https://github.com/solidusio/solidus_starter_frontend.git",
+      "https://github.com/#{owner}/solidus_starter_frontend.git",
       tempdir
     ].map(&:shellescape).join(" ")
 
-    if (branch = __FILE__[%r{solidus_starter_frontend/(.+)/template.rb}, 1])
-      Dir.chdir(tempdir) { git checkout: branch }
-    end
+    Dir.chdir(tempdir) { git checkout: branch } if branch
   else
     repo_dir = File.dirname(__FILE__)
   end

--- a/template.rb
+++ b/template.rb
@@ -40,10 +40,18 @@ def add_template_repository_to_source_path
 end
 
 def install_gems
+  add_solidus_auth_devise_if_missing
   add_solidus_starter_frontend_dependencies
   add_solidus_starter_frontend_spec_dependencies
 
   run_bundle
+end
+
+def add_solidus_auth_devise_if_missing
+  unless Bundler.locked_gems.dependencies['solidus_auth_devise']
+    bundle_command 'add solidus_auth_devise'
+    generate 'solidus:auth:install'
+  end
 end
 
 def add_solidus_starter_frontend_dependencies

--- a/template.rb
+++ b/template.rb
@@ -41,7 +41,7 @@ end
 
 def install_gems
   add_solidus_starter_frontend_dependencies
-  add_spec_gems
+  add_solidus_starter_frontend_spec_dependencies
 
   run_bundle
 end
@@ -53,7 +53,7 @@ def add_solidus_starter_frontend_dependencies
   gem 'view_component', '~> 2.46'
 end
 
-def add_spec_gems
+def add_solidus_starter_frontend_spec_dependencies
   gem_group :development, :test do
     gem 'rspec-rails'
     gem 'apparition', '~> 0.6.0', github: 'twalpole/apparition'

--- a/template.rb
+++ b/template.rb
@@ -23,7 +23,7 @@ def add_template_repository_to_source_path
 
     git clone: [
       "--quiet",
-      "https://github.com/nebulab/solidus_starter_frontend.git",
+      "https://github.com/solidusio/solidus_starter_frontend.git",
       tempdir
     ].map(&:shellescape).join(" ")
 

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -632,7 +632,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
         # Unlike with the other examples in this spec, calling
         # `checkout_as_guest` in this example causes this example to fail
         # intermittently. Please see
-        # https://github.com/nebulab/solidus_starter_frontend/pull/172/files#r683067589
+        # https://github.com/solidusio/solidus_starter_frontend/pull/172/files#r683067589
         # for more details.
         within '#existing-customer' do
           fill_in 'Email:', with: user.email


### PR DESCRIPTION
With this change the app template can be run on apps that were installed with either `--frontend=none` and `--frontend=solidus_frontend`

## Description

This adds support for:
- ~~removing `solidus_frontend` from the gemfile if it's there~~
- ~~replacing `solidus` with its subcomponents if it's there~~
- adding `solidus_auth_devise` to the gemfile if it's not there

This should be compatible with running it both from the `solidus:install` generator and standalone after the fact.
In order to support both migrations for solidus_auth_devise are not run.

## Motivation and Context

This started with an investigation in https://github.com/solidusio/solidus/discussions/4583.

## How Has This Been Tested?

```
rails new my_app --skip-javascript
cd my_app
bundle add solidus
bin/rails g solidus:install --frontend=none --with-authentication=false
git add .
git commit -m "vanilla rails with solidus"
# and then repeatedly
g reset --hard
g clean -fdx
bin/rails app:template LOCATION=~/Code/Nebulab/solidus_starter_frontend/template.rb --trace
bin/rails db:migrate
bundle exec rspec 
```


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
