### PR TITLE
Fix specs for Ruby 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,9 @@ commands:
 
 jobs:
   run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+    executor:
+        name: solidusio_extensions/postgres
+        ruby_version: '2.7'
     steps:
       - setup
       - test-branch:
@@ -80,7 +82,9 @@ jobs:
           rails_version: "~> 6.1"
       - solidusio_extensions/store-test-results
   run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
+    executor:
+        name: solidusio_extensions/mysql
+        ruby_version: '3.0'
     steps:
       - setup
       - test-branch:
@@ -88,7 +92,9 @@ jobs:
           rails_version: "~> 6.1"
       - solidusio_extensions/store-test-results
   run-specs-with-postgres-and-solidus-latest:
-    executor: solidusio_extensions/postgres
+    executor:
+        name: solidusio_extensions/postgres
+        ruby_version: '3.0'
     steps:
       - setup
       - test-branch:
@@ -96,7 +102,10 @@ jobs:
           rails_version: "~> 7.0"
       - solidusio_extensions/store-test-results
   run-specs-with-mysql-and-solidus-latest:
-    executor: solidusio_extensions/mysql
+    executor:
+        name: solidusio_extensions/mysql
+        ruby_version: '3.1'
+
     steps:
       - setup
       - test-branch:

--- a/templates/spec/components/taxons_tree_component_spec.rb
+++ b/templates/spec/components/taxons_tree_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe TaxonsTreeComponent, type: :component do
 
   context 'when rendered' do
     before do
-      render_inline(described_class.new(local_assigns))
+      render_inline(described_class.new(**local_assigns))
     end
 
     describe 'concerning max_level and root_taxon' do

--- a/templates/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/templates/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
     let(:password_confirmation) { 'foobar123' }
 
     subject do
-      post(:create, {
+      post(
+        :create,
         params: {
           spree_user: {
             email: 'foobar@example.com',
@@ -23,7 +24,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
             password_confirmation: password_confirmation
           }
         }
-      })
+      )
     end
 
     context 'when user created successfuly' do

--- a/templates/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/templates/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
     let(:password) { 'secret' }
 
     subject do
-      post(:create, {
+      post(
+        :create,
         params: {
           spree_user: {
             email: user.email,
@@ -20,7 +21,7 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
           },
           format: format
         }
-      })
+      )
     end
 
     context "when using correct login information" do

--- a/templates/spec/system/cart_spec.rb
+++ b/templates/spec/system/cart_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Cart', type: :system, inaccessible: true do
     expect(page).to have_content("Your cart is empty")
 
     within "#link-to-cart" do
-      expect(page).to have_no_content
+      expect(page.text).to eq('')
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe 'Cart', type: :system, inaccessible: true do
     expect(page).to have_content("Your cart is empty")
 
     within "#link-to-cart" do
-      expect(page).to have_no_content
+      expect(page.text).to eq('')
     end
   end
 


### PR DESCRIPTION
Currently specs were broken for ruby 3+.

## Description

- keyword argument fixes
- capybara updates
- run the CI mixing and matching ruby/rails/solidus versions

## Motivation and Context

Tried to install it running on ruby 3 and got a bunch of red specs.

## How Has This Been Tested?

- created a new rails app with ruby 3
- added solidus with the new frontend
- ran rspec in the app

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
