### PR TITLE
Embed solidus_dev_support spec helpers and remove the dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ commands:
         type: string
         default: |
           cd sandbox
+          bundle add rspec_junit_formatter --group test
           bundle exec rspec --format progress --format RspecJunitFormatter --out $TEST_RESULTS_PATH
       command_verb:
         type: string

--- a/Guardfile
+++ b/Guardfile
@@ -8,6 +8,7 @@ guard :shell do
       rsync \
         --archive \
         --exclude='config/routes.rb' \
+        --verbose \
         templates/ \
         sandbox
     }

--- a/template.rb
+++ b/template.rb
@@ -67,7 +67,16 @@ def add_solidus_starter_frontend_spec_dependencies
     gem 'apparition', '~> 0.6.0', github: 'twalpole/apparition'
     gem 'rails-controller-testing', '~> 1.0.5'
     gem 'rspec-activemodel-mocks', '~> 1.1.0'
-    gem 'solidus_dev_support', '~> 2.5'
+
+    gem 'capybara-screenshot', '~> 1.0'
+    gem 'database_cleaner', '~> 1.7'
+    gem 'factory_bot', '>= 4.8'
+    gem 'factory_bot_rails'
+    gem 'ffaker', '~> 2.13'
+    gem 'rubocop', '~> 1.0'
+    gem 'rubocop-performance', '~> 1.5'
+    gem 'rubocop-rails', '~> 2.3'
+    gem 'rubocop-rspec', '~> 2.0'
   end
 end
 
@@ -76,6 +85,19 @@ def copy_solidus_starter_frontend_files
 
   copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'
   copy_file 'config/initializers/canonical_rails.rb'
+
+  application <<~RUBY
+    if defined?(FactoryBotRails)
+      initializer after: "factory_bot.set_factory_paths" do
+        require 'spree/testing_support'
+        FactoryBot.definition_file_paths = [
+          *Spree::TestingSupport::FactoryBot.definition_file_paths,
+          Rails.root.join('spec/fixtures/factories'),
+        ]
+      end
+    end
+
+  RUBY
 
   copy_file 'config/routes.rb', 'tmp/routes.rb'
   prepend_file 'config/routes.rb', File.read('tmp/routes.rb')

--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -94,27 +94,6 @@ RSpec.configure do |config|
   end
 end
 
-dev_support_assets_preload = ->(*) {
-  if Rails.application.respond_to?(:precompiled_assets)
-    Rails.application.precompiled_assets
-  else
-    # For older sprockets 2.x
-    Rails.application.config.assets.precompile.each do |asset|
-      Rails.application.assets.find_asset(asset)
-    end
-  end
-}
-
-RSpec.configure do |config|
-  config.when_first_matching_example_defined(type: :feature) do
-    config.before :suite, &dev_support_assets_preload
-  end
-
-  config.when_first_matching_example_defined(type: :system) do
-    config.before :suite, &dev_support_assets_preload
-  end
-end
-
 # END require 'solidus_dev_support/rspec/feature_helper'
 require 'spree/testing_support/caching'
 require 'spree/testing_support/order_walkthrough'

--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -7,24 +7,6 @@ require 'rspec/active_model/mocks'
 
 require "view_component/test_helpers"
 
-# Requires factories and other useful helpers defined in spree_core.
-# START require 'solidus_dev_support/rspec/feature_helper'
-RSpec.configure do |config|
-  config.filter_run focus: true
-  config.run_all_when_everything_filtered = true
-
-  config.mock_with :rspec
-  config.color = true
-
-  config.fail_fast = ENV.fetch('FAIL_FAST', false)
-  config.order = 'random'
-
-  config.raise_errors_for_deprecations!
-
-  config.example_status_persistence_file_path = "./spec/examples.txt"
-
-  Kernel.srand config.seed
-end
 require 'rspec/rails'
 require 'database_cleaner'
 require 'factory_bot'
@@ -34,56 +16,6 @@ require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/controller_requests'
-
-RSpec.configure do |config|
-  config.infer_spec_type_from_file_location!
-
-  config.include FactoryBot::Syntax::Methods
-
-  # visit spree.admin_path
-  # current_path.should eql(spree.products_path)
-  config.include Spree::TestingSupport::UrlHelpers
-
-  config.include Spree::TestingSupport::ControllerRequests, type: :controller
-
-  config.include Spree::TestingSupport::Preferences
-
-  config.before do
-    ActiveJob::Base.queue_adapter = :test
-  end
-
-  config.include ActiveJob::TestHelper
-
-  config.after(:suite) do
-    if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
-      Rails.autoloaders.main.class.eager_load_all
-    end
-  rescue NameError => e
-    class ZeitwerkNameError < NameError; end
-
-    error_message =
-      if e.message =~ /expected file .*? to define constant [\w:]+/
-        e.message.sub(/expected file #{Regexp.escape(File.expand_path('../..', Rails.root))}./, "expected file ")
-      else
-        e.message
-      end
-
-    message = <<~WARN
-      Zeitwerk raised the following error when trying to eager load your extension:
-
-      #{error_message}
-
-      This most likely means that your extension's file structure is not
-      compatible with the Zeitwerk autoloader.
-      Refer to https://github.com/solidusio/solidus_support#engine-extensions in
-      order to update the file structure to match Zeitwerk's expectations.
-    WARN
-
-    raise ZeitwerkNameError, message
-  end
-end
-
-# END require 'solidus_dev_support/rspec/feature_helper'
 require 'spree/testing_support/caching'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/translations'
@@ -93,26 +25,51 @@ require 'spree/testing_support/translations'
 Dir["#{__dir__}/support/solidus_starter_frontend/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+  config.mock_with :rspec
+  config.color = true
+  config.fail_fast = ENV.fetch('FAIL_FAST', false)
+  config.order = 'random'
+  config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  Kernel.srand config.seed
+
+  config.raise_errors_for_deprecations!
+  config.infer_spec_type_from_file_location!
   config.disable_monkey_patching!
   config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = false
+
+  config.include FactoryBot::Syntax::Methods
+  config.include Spree::TestingSupport::UrlHelpers
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
+  config.include Spree::TestingSupport::Preferences
+  config.include Spree::TestingSupport::Translations
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
+  config.include ActiveJob::TestHelper
+
+  config.before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  config.after(:suite) do
+    Rails.autoloaders.main.class.eager_load_all
+  rescue NameError => e
+    raise <<~WARN
+      Zeitwerk raised the following error when trying to eager load your extension:
+
+      #{e.message}
+    WARN
+  end
 
   # We currently have examples wherein we mock or stub method that do not exist on
   # the real objects.
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = false
   end
-
-  if Spree.solidus_gem_version < Gem::Version.new('2.11')
-    config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :system
-  else
-    config.include Spree::TestingSupport::Translations
-  end
-
-  config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::Test::IntegrationHelpers, type: :request
-  config.include ViewComponent::TestHelpers, type: :component
-  config.include Capybara::RSpecMatchers, type: :component
 
   config.before(:each, with_signed_in_user: true) do
     sign_in(user)

--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -48,19 +48,8 @@ RSpec.configure do |config|
 
   config.include Spree::TestingSupport::Preferences
 
-  config.before :suite do
-    DatabaseCleaner.clean_with :truncation
-  end
-
   config.before do
     ActiveJob::Base.queue_adapter = :test
-  end
-
-  # Around each spec check if it is a Javascript test and switch between using
-  # database transactions or not where necessary.
-  config.around(:each) do |example|
-    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.cleaning { example.run }
   end
 
   config.include ActiveJob::TestHelper

--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -143,7 +143,7 @@ end
 # END require 'solidus_dev_support/rspec/feature_helper'
 require 'spree/testing_support/caching'
 require 'spree/testing_support/order_walkthrough'
-require 'spree/testing_support/translations' unless Spree.solidus_gem_version < Gem::Version.new('2.11')
+require 'spree/testing_support/translations'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -9,7 +9,138 @@ require "view_component/test_helpers"
 require "capybara/rspec"
 
 # Requires factories and other useful helpers defined in spree_core.
-require 'solidus_dev_support/rspec/feature_helper'
+# START require 'solidus_dev_support/rspec/feature_helper'
+RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
+  config.mock_with :rspec
+  config.color = true
+
+  config.fail_fast = ENV.fetch('FAIL_FAST', false)
+  config.order = 'random'
+
+  config.raise_errors_for_deprecations!
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  Kernel.srand config.seed
+end
+require 'rspec/rails'
+require 'database_cleaner'
+require 'factory_bot'
+require 'ffaker'
+
+require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/url_helpers'
+require 'spree/testing_support/preferences'
+require 'spree/testing_support/controller_requests'
+
+RSpec.configure do |config|
+  config.infer_spec_type_from_file_location!
+
+  config.include FactoryBot::Syntax::Methods
+
+  # visit spree.admin_path
+  # current_path.should eql(spree.products_path)
+  config.include Spree::TestingSupport::UrlHelpers
+
+  config.include Spree::TestingSupport::ControllerRequests, type: :controller
+
+  config.include Spree::TestingSupport::Preferences
+
+  config.before :suite do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  config.before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  # Around each spec check if it is a Javascript test and switch between using
+  # database transactions or not where necessary.
+  config.around(:each) do |example|
+    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.cleaning { example.run }
+  end
+
+  config.include ActiveJob::TestHelper
+
+  config.after(:suite) do
+    if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
+      Rails.autoloaders.main.class.eager_load_all
+    end
+  rescue NameError => e
+    class ZeitwerkNameError < NameError; end
+
+    error_message =
+      if e.message =~ /expected file .*? to define constant [\w:]+/
+        e.message.sub(/expected file #{Regexp.escape(File.expand_path('../..', Rails.root))}./, "expected file ")
+      else
+        e.message
+      end
+
+    message = <<~WARN
+      Zeitwerk raised the following error when trying to eager load your extension:
+
+      #{error_message}
+
+      This most likely means that your extension's file structure is not
+      compatible with the Zeitwerk autoloader.
+      Refer to https://github.com/solidusio/solidus_support#engine-extensions in
+      order to update the file structure to match Zeitwerk's expectations.
+    WARN
+
+    raise ZeitwerkNameError, message
+  end
+end
+
+require 'capybara-screenshot/rspec'
+require 'webdrivers/chromedriver'
+
+# Allow to override the initial windows size
+CAPYBARA_WINDOW_SIZE = ENV.fetch('CAPYBARA_WINDOW_SIZE', '1920x1080').split('x', 2).map(&:to_i)
+CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]
+CAPYBARA_WINDOW_HEIGHT = CAPYBARA_WINDOW_SIZE[1]
+
+Capybara.javascript_driver = ENV.fetch('CAPYBARA_JAVASCRIPT_DRIVER', "solidus_chrome_headless").to_sym
+Capybara.default_max_wait_time = 10
+Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
+
+Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
+  Capybara.register_driver :solidus_chrome_headless do |app|
+    original_driver.call(app).tap do |driver|
+      driver.resize_window_to(
+        driver.current_window_handle, CAPYBARA_WINDOW_WIDTH, CAPYBARA_WINDOW_HEIGHT
+      )
+    end
+  end
+end
+
+require 'spree/testing_support/capybara_ext'
+
+dev_support_assets_preload = ->(*) {
+  if Rails.application.respond_to?(:precompiled_assets)
+    Rails.application.precompiled_assets
+  else
+    # For older sprockets 2.x
+    Rails.application.config.assets.precompile.each do |asset|
+      Rails.application.assets.find_asset(asset)
+    end
+  end
+}
+
+RSpec.configure do |config|
+  config.when_first_matching_example_defined(type: :feature) do
+    config.before :suite, &dev_support_assets_preload
+  end
+
+  config.when_first_matching_example_defined(type: :system) do
+    config.before :suite, &dev_support_assets_preload
+  end
+end
+
+# END require 'solidus_dev_support/rspec/feature_helper'
 require 'spree/testing_support/caching'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/translations' unless Spree.solidus_gem_version < Gem::Version.new('2.11')

--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -6,7 +6,6 @@ require 'rails-controller-testing'
 require 'rspec/active_model/mocks'
 
 require "view_component/test_helpers"
-require "capybara/rspec"
 
 # Requires factories and other useful helpers defined in spree_core.
 # START require 'solidus_dev_support/rspec/feature_helper'
@@ -94,30 +93,6 @@ RSpec.configure do |config|
     raise ZeitwerkNameError, message
   end
 end
-
-require 'capybara-screenshot/rspec'
-require 'webdrivers/chromedriver'
-
-# Allow to override the initial windows size
-CAPYBARA_WINDOW_SIZE = ENV.fetch('CAPYBARA_WINDOW_SIZE', '1920x1080').split('x', 2).map(&:to_i)
-CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]
-CAPYBARA_WINDOW_HEIGHT = CAPYBARA_WINDOW_SIZE[1]
-
-Capybara.javascript_driver = ENV.fetch('CAPYBARA_JAVASCRIPT_DRIVER', "solidus_chrome_headless").to_sym
-Capybara.default_max_wait_time = 10
-Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
-
-Capybara.drivers[:selenium_chrome_headless].tap do |original_driver|
-  Capybara.register_driver :solidus_chrome_headless do |app|
-    original_driver.call(app).tap do |driver|
-      driver.resize_window_to(
-        driver.current_window_handle, CAPYBARA_WINDOW_WIDTH, CAPYBARA_WINDOW_HEIGHT
-      )
-    end
-  end
-end
-
-require 'spree/testing_support/capybara_ext'
 
 dev_support_assets_preload = ->(*) {
   if Rails.application.respond_to?(:precompiled_assets)

--- a/templates/spec/support/solidus_starter_frontend/capybara.rb
+++ b/templates/spec/support/solidus_starter_frontend/capybara.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
+require 'capybara/rspec'
+require 'capybara-screenshot/rspec'
 require 'capybara/apparition'
+require 'spree/testing_support/capybara_ext'
+
+# Allow to override the initial windows size
+CAPYBARA_WINDOW_SIZE = ENV.fetch('CAPYBARA_WINDOW_SIZE', '1920x1080').split('x', 2).map(&:to_i)
+CAPYBARA_WINDOW_WIDTH = CAPYBARA_WINDOW_SIZE[0]
+CAPYBARA_WINDOW_HEIGHT = CAPYBARA_WINDOW_SIZE[1]
+
+Capybara.javascript_driver = ENV.fetch('CAPYBARA_JAVASCRIPT_DRIVER', "solidus_chrome_headless").to_sym
+Capybara.default_max_wait_time = 10
+Capybara.server = :puma, { Silent: true } # A fix for rspec/rspec-rails#1897
 
 Capybara.register_driver :apparition do |app|
   Capybara::Apparition::Driver.new(app, window_size: CAPYBARA_WINDOW_SIZE)

--- a/templates/spec/support/solidus_starter_frontend/database_cleaner.rb
+++ b/templates/spec/support/solidus_starter_frontend/database_cleaner.rb
@@ -1,0 +1,13 @@
+RSpec.configure do |config|
+  config.use_transactional_fixtures = false
+  config.before :suite do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  # Around each spec check if it is a Javascript test and switch between using
+  # database transactions or not where necessary.
+  config.around(:each) do |example|
+    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.cleaning { example.run }
+  end
+end

--- a/templates/spec/support/solidus_starter_frontend/features/assets.rb
+++ b/templates/spec/support/solidus_starter_frontend/features/assets.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.when_first_matching_example_defined(type: :feature) do
+    config.before(:suite) { Rails.application.precompiled_assets }
+  end
+
+  config.when_first_matching_example_defined(type: :system) do
+    config.before(:suite) { Rails.application.precompiled_assets }
+  end
+end
+


### PR DESCRIPTION
Albeit `solidus_dev_support` simplified a few things with the rspec setup it was never intended to be used in stores, but rather only to aid extension development.

## Description

- Embed what we needed for the current project from dev-support
- Remove support for older Solidus version

## Motivation and Context

This change was suggested by an issue raised in the `#support` channel on slack about the changelog generator dependency relying on a version of the `async` gem which is only compatible with Ruby 3.

## How Has This Been Tested?

Relying on the current suite.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
