### PR TITLE
Faster clones for the templates repo

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -21,15 +21,16 @@ def add_template_repository_to_source_path
     url_path = URI.parse(__FILE__).path
     branch = url_path[%r{solidus_starter_frontend/(raw/)?(.+?)/template.rb}, 2]
     owner = url_path[%r{/([^/]+)/solidus_starter_frontend/}, 1]
+
     at_exit { FileUtils.remove_entry(tempdir) }
 
     git clone: [
       "--quiet",
+      "--depth", "1",
+      *(["--branch", branch] if branch),
       "https://github.com/#{owner}/solidus_starter_frontend.git",
       tempdir
     ].map(&:shellescape).join(" ")
-
-    Dir.chdir(tempdir) { git checkout: branch } if branch
   else
     repo_dir = File.dirname(__FILE__)
   end


### PR DESCRIPTION
Improve reliability and performance with a shallow clone.

## Description

Since the clone is quite disposable we can be efficient and do a shallow clone of the branch we're interested in.

We're assuming that when used locally we have a git repo available and that all files are committed.

## Motivation and Context

Having the code work both from a file and from a remote git clone can hide some bugs (since the CI will only run with local code). 

## How Has This Been Tested?

The CI now covers most of the git related code, since it's shared.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
