### PR TITLE
Refactor SolidusStarterFrontend CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,32 +100,27 @@ workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs:
-          name: run-specs-with-postgres
-          database: 'postgres'
+          name: run-specs-with-solidus-3-2-rails-7-ruby-3-1-postgres
+
+      - run-specs:
+          name: run-specs-but-with-solidus-latest
+          solidus_branch: 'master'
+
+      - run-specs:
+          name: run-specs-but-with-rails-6
+          rails_version: '~> 6.1'
+
+      - run-specs:
+          name: run-specs-but-with-ruby-3-0
+          ruby_version: '3.0'
+
+      - run-specs:
+          name: run-specs-but-with-ruby-2
           ruby_version: '2.7'
-          solidus_branch: 'v3.1'
-          rails_version: '~> 6.1'
 
       - run-specs:
-          name: run-specs-with-mysql
+          name: run-specs-but-with-mysql
           database: 'mysql'
-          ruby_version: '3.0'
-          solidus_branch: 'v3.1'
-          rails_version: '~> 6.1'
-
-      - run-specs:
-          name: run-specs-with-postgres-and-solidus-latest
-          database: 'postgres'
-          ruby_version: '3.0'
-          solidus_branch: 'master'
-          rails_version: '~> 7.0'
-
-      - run-specs:
-          name: run-specs-with-mysql-and-solidus-latest
-          database: 'mysql'
-          ruby_version: '3.1'
-          solidus_branch: 'master'
-          rails_version: '~> 7.0'
 
   "Weekly run specs against master":
     triggers:
@@ -137,29 +132,24 @@ workflows:
                 - master
     jobs:
       - run-specs:
-          name: run-specs-with-postgres
-          database: 'postgres'
+          name: run-specs-with-solidus-3-2-rails-7-ruby-3-1-postgres
+
+      - run-specs:
+          name: run-specs-but-with-solidus-latest
+          solidus_branch: 'master'
+
+      - run-specs:
+          name: run-specs-but-with-rails-6
+          rails_version: '~> 6.1'
+
+      - run-specs:
+          name: run-specs-but-with-ruby-3-0
+          ruby_version: '3.0'
+
+      - run-specs:
+          name: run-specs-but-with-ruby-2
           ruby_version: '2.7'
-          solidus_branch: 'v3.1'
-          rails_version: '~> 6.1'
 
       - run-specs:
-          name: run-specs-with-mysql
+          name: run-specs-but-with-mysql
           database: 'mysql'
-          ruby_version: '3.0'
-          solidus_branch: 'v3.1'
-          rails_version: '~> 6.1'
-
-      - run-specs:
-          name: run-specs-with-postgres-and-solidus-latest
-          database: 'postgres'
-          ruby_version: '3.0'
-          solidus_branch: 'master'
-          rails_version: '~> 7.0'
-
-      - run-specs:
-          name: run-specs-with-mysql-and-solidus-latest
-          database: 'mysql'
-          ruby_version: '3.1'
-          solidus_branch: 'master'
-          rails_version: '~> 7.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,55 +72,61 @@ commands:
           when: always
 
 jobs:
-  run-specs-with-postgres:
+  run-specs:
     executor:
-        name: solidusio_extensions/postgres
-        ruby_version: '2.7'
+        name: solidusio_extensions/<<parameters.database>>
+        ruby_version: <<parameters.ruby_version>>
     steps:
       - setup
       - test-branch:
-          branch: v3.1
-          rails_version: "~> 6.1"
+          branch: <<parameters.solidus_branch>>
+          rails_version: <<parameters.rails_version>>
       - solidusio_extensions/store-test-results
-  run-specs-with-mysql:
-    executor:
-        name: solidusio_extensions/mysql
-        ruby_version: '3.0'
-    steps:
-      - setup
-      - test-branch:
-          branch: v3.1
-          rails_version: "~> 6.1"
-      - solidusio_extensions/store-test-results
-  run-specs-with-postgres-and-solidus-latest:
-    executor:
-        name: solidusio_extensions/postgres
-        ruby_version: '3.0'
-    steps:
-      - setup
-      - test-branch:
-          branch: master
-          rails_version: "~> 7.0"
-      - solidusio_extensions/store-test-results
-  run-specs-with-mysql-and-solidus-latest:
-    executor:
-        name: solidusio_extensions/mysql
-        ruby_version: '3.1'
-
-    steps:
-      - setup
-      - test-branch:
-          branch: master
-          rails_version: "~> 7.0"
-      - solidusio_extensions/store-test-results
+    parameters:
+      solidus_branch:
+        type: string
+        default: 'v3.2'
+      rails_version:
+        type: string
+        default: '~> 7.0'
+      ruby_version:
+        type: string
+        default: '3.1'
+      database:
+        type: string
+        default: 'postgres'
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
-      - run-specs-with-postgres-and-solidus-latest
-      - run-specs-with-mysql-and-solidus-latest
+      - run-specs:
+          name: run-specs-with-postgres
+          database: 'postgres'
+          ruby_version: '2.7'
+          solidus_branch: 'v3.1'
+          rails_version: '~> 6.1'
+
+      - run-specs:
+          name: run-specs-with-mysql
+          database: 'mysql'
+          ruby_version: '3.0'
+          solidus_branch: 'v3.1'
+          rails_version: '~> 6.1'
+
+      - run-specs:
+          name: run-specs-with-postgres-and-solidus-latest
+          database: 'postgres'
+          ruby_version: '3.0'
+          solidus_branch: 'master'
+          rails_version: '~> 7.0'
+
+      - run-specs:
+          name: run-specs-with-mysql-and-solidus-latest
+          database: 'mysql'
+          ruby_version: '3.1'
+          solidus_branch: 'master'
+          rails_version: '~> 7.0'
+
   "Weekly run specs against master":
     triggers:
       - schedule:
@@ -130,7 +136,30 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
-      - run-specs-with-postgres-and-solidus-latest
-      - run-specs-with-mysql-and-solidus-latest
+      - run-specs:
+          name: run-specs-with-postgres
+          database: 'postgres'
+          ruby_version: '2.7'
+          solidus_branch: 'v3.1'
+          rails_version: '~> 6.1'
+
+      - run-specs:
+          name: run-specs-with-mysql
+          database: 'mysql'
+          ruby_version: '3.0'
+          solidus_branch: 'v3.1'
+          rails_version: '~> 6.1'
+
+      - run-specs:
+          name: run-specs-with-postgres-and-solidus-latest
+          database: 'postgres'
+          ruby_version: '3.0'
+          solidus_branch: 'master'
+          rails_version: '~> 7.0'
+
+      - run-specs:
+          name: run-specs-with-mysql-and-solidus-latest
+          database: 'mysql'
+          ruby_version: '3.1'
+          solidus_branch: 'master'
+          rails_version: '~> 7.0'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Just run:
 rails new store --skip-javascript
 cd store
 bundle add solidus
-bin/rails generate solidus:install --frontend=soldius_starter_frontend
+bin/rails generate solidus:install --frontend=solidus_starter_frontend
 ```
 
 That will create a new Solidus application with SolidusStarterFrontend as its

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ All of this while keeping and improving on the functionality of the current
 
 ## Installation
 
-### For a new store
-
 Just run:
 
 ```bash
@@ -41,37 +39,6 @@ storefront.
 
 Please note that [Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
 will also be added to your application as it's required by SolidusStarterFrontend.
-
-### For existing stores
-
-In your `Gemfile` replace:
-
-```ruby
-gem 'solidus'
-```
-
-with:
-
-```ruby
-gem 'solidus_core'
-gem 'solidus_api'
-gem 'solidus_backend'
-gem 'solidus_sample'
-```
-
-And replace all the references of the string `Spree::Frontend::Config` in your
-project with their actual values.
-
-You'll also need to make sure that
-[Solidus Auth Devise](https://github.com/solidusio/solidus_auth_devise)
-is installed in your application.
-
-Then you can run the app template with this command:
-
-```shell
-$ bin/rails app:template LOCATION="https://github.com/solidusio/solidus_starter_frontend/raw/master/template.rb"
-$ bin/rails db:migrate
-```
 
 ## Considerations
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -69,6 +69,13 @@ gem 'solidus_i18n', github: solidus_i18n_repo, branch: solidus_i18n_branch
 
 gem 'rails-i18n'
 gem 'solidus_auth_devise'
+
+# mail gem dependencies
+# Prevents "cannot load such file -- net/smtp" with Ruby 3.1 and Rails 6.
+# See https://stackoverflow.com/a/70500221/65925.
+gem 'net-smtp', require: false
+gem 'net-imap', require: false
+gem 'net-pop', require: false
 RUBY
 
 replace_in_database_yml() {


### PR DESCRIPTION
Goal
----

As a SolidusStarterFrontend maintainer, I want to be able to 

* Clearly see the differences of SolidusStarterFrontend CircleCI jobs against each other.
* Test SolidusStarterFrontend against Ruby, Rails, and DB versions supported by the latest Solidus version.

Background
----------

<https://github.com/solidusio/solidus_starter_frontend/commit/4bebb8d0df761ddb86306bf585cf5a82d4def572> updated the Circle CI config to mix and match Ruby, Rails, and Solidus versions. However, with the introduction of different Ruby versions to the jobs, the job names no longer adequately describe the scenarios they run.

Proposed solution
-----------------

-   Define a `run-specs` job with the following default parameters:
    -   Solidus Branch: v3.2
    -   Rails version: 7.0
    -   Ruby version: 3.1
    -   Database: Postgres

-   Use [CircleCI job parameters](https://circleci.com/docs/jobs-steps#passing-parameters-to-jobshttps://circleci.com/docs/jobs-steps#passing-parameters-to-jobs) to call `run-specs` but with different parameters.

-   Create additional jobs for the following scenarios:
    -   Solidus branch
        -   master
    -   Rails
        -   ~> 6.1
    -   Ruby
        - 3.0.4
        - 2.7.6
    -   Database
        -   MySQL

## What about Rails 5.2?

I tried testing SSF with Rails 5.2, but I encountered the following issues. Please see the table below. In each row, I indicate the possible solution I tried to fix the issue:

| Solidus | Rails | Ruby  | Psych | Discard | Issue                                                                                                                                                             | Possible solution                                                        |
|---------|-------|-------|-------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
| 3.2     | 5.2   | 3.0   | N/A   | N/A     | Rails 5.2 doesn't work with Ruby 3.0 · Issue [#40938](https://github.com/rails/rails/issues/40938) – GitHub                                                                                                      | Lower Ruby to 2.7.6                                                      |
| 3.2     | 5.2   | 2.7.6 | N/A   | N/A     | Getting “Psych::BadAlias: Cannot load database configuration: Unknown alias: default” when running bin/sandbox.                                                   | Lower Psych to < 4.0                                                     |
| 3.2     | 5.2   | 2.7.6 | 3.3.3 | N/A     | NameError: undefined local variable or method `acts_as_paranoid' for #<Class:0x000055b1b970d058> - Paranoia gem has been replaced by Discard gem in [Solidus 3.0.0](https://github.com/solidusio/solidus/blob/bdebdbc15457487ab412702a02980bbbe32d3a6e/CHANGELOG.md#solidus-300-v30-2021-04-20) | Lower Solidus to 2.11.                                                   |
| 2.11.17 | 5.2   | 2.7.6 | 3.3.3 | N/A     | NameError: uninitialized constant Spree::User::Discard                                                                                                            | Add discard gem                                                          |
| 2.11.17 | 5.2   | 2.7.6 | 3.3.3 | 1.2.1   | undefined method `autoloaders' for Rails:Module                                                                                                                   | **Haven't tried**: Monkey-patch Spree::BaseHelpers with classic Rails loading for Rails 5.2 |

Please see https://github.com/solidusio/solidus_starter_frontend/tree/gsmendoza/sol-429-refactor-solidusstarterfrontend-circleci--rails-5-2 for the working branch for Rails 5.2 support.

Because it's getting complicated to get SolidusStarterFrontend to work with Rails 5.2, and because Rails 5.2 has already reached [end of life](https://endoflife.date/rails), I intend to no longer add a Rails 5.2 job to the CircleCI config.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
