### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Just run:
 rails new store --skip-javascript
 cd store
 bundle add solidus
-bin/rails generate solidus:install --frontend=soldius_starter_frontend
+bin/rails generate solidus:install --frontend=solidus_starter_frontend
 ```
 
 That will create a new Solidus application with SolidusStarterFrontend as its
@@ -69,7 +69,7 @@ is installed in your application.
 Then you can run the app template with this command:
 
 ```shell
-$ bin/rails app:template LOCATION="https://github.com/solidusio/solidus_starter_frontend/raw/master/template.rb"
+$ bin/rails app:template LOCATION="https://github.com/solidusio/solidus_starter_frontend/raw/main/template.rb"
 $ bin/rails db:migrate
 ```
 


### PR DESCRIPTION
## Description

- There was a typo in the generator command.
- The main branch is no longer called `master`.

## Motivation and Context

It should not be frustrating for new users to use this generator.

## How Has This Been Tested?

We manually tested the generator command.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
