### PR TITLE
Remove associate_user

### DIFF
--- a/templates/app/controllers/checkout_controller.rb
+++ b/templates/app/controllers/checkout_controller.rb
@@ -14,7 +14,6 @@ class CheckoutController < StoreController
   before_action :ensure_sufficient_stock_lines
   before_action :ensure_valid_state
 
-  before_action :associate_user
   before_action :check_registration, except: [:registration, :update_registration]
   before_action :check_authorization
 

--- a/templates/app/controllers/orders_controller.rb
+++ b/templates/app/controllers/orders_controller.rb
@@ -38,7 +38,6 @@ class OrdersController < StoreController
   def edit
     @order = current_order(build_order_if_necessary: true)
     authorize! :edit, @order, cookies.signed[:guest_token]
-    associate_user
     if params[:id] && @order.number != params[:id]
       flash[:error] = t('spree.cannot_edit_orders')
       redirect_to cart_path

--- a/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
+++ b/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Checkout confirm page submission', :js, type: :system do
   context "when the product from the order is not backorderable but has enough stock quantity" do
     let(:user) { create(:user) }
 
-    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment, user: user) }
     let(:order_product) { order.products.first }
     let(:order_stock_item) { order.line_items.first.variant.stock_items.first }
 

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
 
     before do
       user.wallet.add(credit_card)
-      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
+      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user)
 
       allow_any_instance_of(CheckoutController).to receive_messages(current_order: order)
       allow_any_instance_of(CheckoutController).to receive_messages(spree_current_user: user)
@@ -590,7 +590,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
 
   context "when order is completed" do
     let!(:user) { create(:user) }
-    let!(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
+    let!(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user) }
 
     before(:each) do
       allow_any_instance_of(CheckoutController).to receive_messages(current_order: order)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes `associate_user` from the orders_controller and the checkout_controller.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/solidusio/solidus/pull/4201 for full context.
The method was used before, but now its responsibilities are fulfilled by the solidus_auth_devise which this repo depends on.

Some tests were modified to provide a user with an order being tested. Previously these tests assumed a user could have an order not associated with and navigate to a point in checkout for that order. In the checkout flow, the user will have an order associated with them after logging in which is fulfilled by a [hook on after_set_user in solidus_auth_devise](https://github.com/solidusio/solidus_auth_devise/blob/09841c164e1d0e6ab7afbb80494737fc692eb806/config/initializers/warden.rb#L4). The order association functionality is also[ tested within the solidus_auth_devise gem](https://github.com/solidusio/solidus_auth_devise/blob/master/spec/features/checkout_spec.rb#L73). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The current testing suite covers changes - Manually tested checkout flow to ensure user is associated with the order

