### PR TITLE
Convert monkey-patched helpers in Spree::BaseHelper to view components

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -93,22 +93,6 @@ def copy_solidus_starter_frontend_files
   append_file 'config/initializers/devise.rb', File.read('tmp/devise.rb')
 
   application <<~RUBY
-    if Rails.autoloaders.main
-      # Rails 7
-      Rails.autoloaders.main.ignore(Rails.root.join('app/monkey_patches'))
-    else
-      # Rails 6 and older
-      config.after_initialize do
-        Rails.autoloaders.main.ignore(Rails.root.join('app/monkey_patches'))
-      end
-    end
-
-    config.to_prepare do
-      Dir.glob(Rails.root.join('app/monkey_patches/**/*_monkey_patch.rb')).each do |monkey_patch|
-        load monkey_patch
-      end
-    end
-
     if defined?(FactoryBotRails)
       initializer after: "factory_bot.set_factory_paths" do
         require 'spree/testing_support'

--- a/templates/app/components/logo_component.rb
+++ b/templates/app/components/logo_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class LogoComponent < ViewComponent::Base
+  attr_reader :image_path
+
+  def initialize(image_path = Spree::Config[:logo])
+    @image_path = image_path
+  end
+
+  def call
+    link_to image_tag(image_path), root_path
+  end
+end

--- a/templates/app/components/seo_url_component.rb
+++ b/templates/app/components/seo_url_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SeoUrlComponent < ViewComponent::Base
+  attr_reader :taxon
+  
+  def initialize(taxon)
+    @taxon = taxon
+  end
+
+  def call
+    nested_taxons_path(taxon.permalink)
+  end
+end

--- a/templates/app/components/taxons_tree_component.rb
+++ b/templates/app/components/taxons_tree_component.rb
@@ -39,16 +39,12 @@ class TaxonsTreeComponent < ViewComponent::Base
         css_class = 'current' if current_taxon&.self_and_ancestors&.include?(taxon)
 
         content_tag :li, class: css_class do
-          link_to(taxon.name, seo_url(taxon)) +
+          link_to(taxon.name, render(SeoUrlComponent.new(taxon))) +
             tree(root_taxon: taxon, base_class: nil, max_level: max_level - 1)
         end
       end
 
       safe_join(taxons, "\n")
     end
-  end
-
-  def seo_url(taxon)
-    helpers.nested_taxons_path(taxon.permalink)
   end
 end

--- a/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
+++ b/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require 'carmen'
-
-module Spree
-  module BaseHelper
-  end
-end

--- a/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
+++ b/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
@@ -4,47 +4,8 @@ require 'carmen'
 
 module Spree
   module BaseHelper
-    def link_to_cart(text = nil)
-      text = text ? h(text) : t('spree.cart')
-      css_class = nil
-
-      if current_order.nil? || current_order.item_count.zero?
-        text = "#{text}: (#{t('spree.empty')})"
-        css_class = 'empty'
-      else
-        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{current_order.display_total.to_html}</span>"
-        css_class = 'full'
-      end
-
-      link_to text.html_safe, cart_path, class: "cart-info #{css_class}"
-    end
-
     def logo(image_path = Spree::Config[:logo])
       link_to image_tag(image_path), root_path
-    end
-
-    def taxon_breadcrumbs(taxon, separator = '&nbsp;&raquo;&nbsp;', breadcrumb_class = 'inline')
-      return '' if current_page?('/') || taxon.nil?
-
-      crumbs = [[t('spree.home'), root_path]]
-
-      crumbs << [t('spree.products'), products_path]
-      if taxon
-        crumbs += taxon.ancestors.collect { |ancestor| [ancestor.name, nested_taxons_path(ancestor.permalink)] } unless taxon.ancestors.empty?
-        crumbs << [taxon.name, nested_taxons_path(taxon.permalink)]
-      end
-
-      separator = raw(separator)
-
-      items = crumbs.each_with_index.collect do |crumb, index|
-        content_tag(:li, itemprop: 'itemListElement', itemscope: '', itemtype: 'https://schema.org/ListItem') do
-          link_to(crumb.last, itemprop: 'item') do
-            content_tag(:span, crumb.first, itemprop: 'name') + tag('meta', { itemprop: 'position', content: (index + 1).to_s }, false, false)
-          end + (crumb == crumbs.last ? '' : separator)
-        end
-      end
-
-      content_tag(:nav, content_tag(:ol, raw(items.map(&:mb_chars).join), class: breadcrumb_class, itemscope: '', itemtype: 'https://schema.org/BreadcrumbList'), id: 'breadcrumbs', class: 'sixteen columns')
     end
 
     def seo_url(taxon)

--- a/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
+++ b/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
@@ -4,10 +4,6 @@ require 'carmen'
 
 module Spree
   module BaseHelper
-    def logo(image_path = Spree::Config[:logo])
-      link_to image_tag(image_path), root_path
-    end
-
     def seo_url(taxon)
       nested_taxons_path(taxon.permalink)
     end

--- a/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
+++ b/templates/app/monkey_patches/spree/base_helper_monkey_patch.rb
@@ -4,8 +4,5 @@ require 'carmen'
 
 module Spree
   module BaseHelper
-    def seo_url(taxon)
-      nested_taxons_path(taxon.permalink)
-    end
   end
 end

--- a/templates/app/views/layouts/_top_bar.html.erb
+++ b/templates/app/views/layouts/_top_bar.html.erb
@@ -1,6 +1,6 @@
 <div class="top-bar">
   <figure class="logo">
-    <%= logo %>
+    <%= render LogoComponent.new %>
   </figure>
 
   <div class="top-bar__search">

--- a/templates/app/views/products/_product_taxons.html.erb
+++ b/templates/app/views/products/_product_taxons.html.erb
@@ -7,7 +7,7 @@
     <ul class="product-taxons__list">
       <% product.taxons.each do |taxon| %>
         <li>
-          <%= link_to taxon.name, seo_url(taxon) %>
+          <%= link_to taxon.name, render(SeoUrlComponent.new(taxon)) %>
         </li>
       <% end %>
     </ul>

--- a/templates/app/views/products/_products_by_taxon.html.erb
+++ b/templates/app/views/products/_products_by_taxon.html.erb
@@ -1,6 +1,6 @@
 <section class="products-by-taxon">
   <h5 class="products-by-taxon__title">
-    <%= link_to products_by_taxon.name, seo_url(products_by_taxon) %>
+    <%= link_to products_by_taxon.name, render(SeoUrlComponent.new(products_by_taxon)) %>
   </h5>
 
   <%= render 'products/products', products: taxon_preview(products_by_taxon), taxon: products_by_taxon %>


### PR DESCRIPTION
## Goal

As a SolidusStarterFrontend maintainer
I want to convert the monkey-patched helpers in `Spree::BaseHelper` to view components
So that we can remove monkey-patches from SolidusStarterFrontend.

## Background

See discussion in <https://github.com/solidusio/solidus_starter_frontend/pull/255>.

## To follow

I intend to add tests for the new components in a future PR; they previously didn't have unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
~- [ ] Bug fix (non-breaking change which fixes an issue)~
~- [ ] New feature (non-breaking change which adds functionality)~
~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
~- [ ] My change requires a change to the documentation.~
~- [ ] I have updated the documentation accordingly.~
