### PR TITLE
Extract StoreDeviseController

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -92,6 +92,7 @@ def copy_solidus_starter_frontend_files
 
   append_file 'config/initializers/devise.rb', <<~RUBY
     Devise.setup do |config|
+      config.parent_controller = 'StoreDeviseController'
       config.mailer = 'UserMailer'
     end
   RUBY

--- a/templates/app/controllers/store_devise_controller.rb
+++ b/templates/app/controllers/store_devise_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class StoreDeviseController < ApplicationController
+  helper 'spree/base', 'spree/store'
+
+  include Spree::Core::ControllerHelpers::Auth
+  include Spree::Core::ControllerHelpers::Common
+  include Spree::Core::ControllerHelpers::Order
+  include Spree::Core::ControllerHelpers::Store
+  include Taxonomies
+
+  layout 'storefront'
+end

--- a/templates/app/controllers/user_confirmations_controller.rb
+++ b/templates/app/controllers/user_confirmations_controller.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class UserConfirmationsController < Devise::ConfirmationsController
-  helper 'spree/base', 'spree/store'
-
-  include Spree::Core::ControllerHelpers::Auth
-  include Spree::Core::ControllerHelpers::Common
-  include Spree::Core::ControllerHelpers::Order
-  include Spree::Core::ControllerHelpers::Store
-  include Taxonomies
-
-  layout 'storefront'
-
   protected
 
   def after_confirmation_path_for(resource_name, resource)

--- a/templates/app/controllers/user_passwords_controller.rb
+++ b/templates/app/controllers/user_passwords_controller.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class UserPasswordsController < Devise::PasswordsController
-  helper 'spree/base', 'spree/store'
-
-  include Spree::Core::ControllerHelpers::Auth
-  include Spree::Core::ControllerHelpers::Common
-  include Spree::Core::ControllerHelpers::Order
-  include Spree::Core::ControllerHelpers::Store
-  include Taxonomies
-
-  layout 'storefront'
-
   # Overridden due to bug in Devise.
   #   respond_with resource, location: new_session_path(resource_name)
   # is generating bad url /session/new.user

--- a/templates/app/controllers/user_registrations_controller.rb
+++ b/templates/app/controllers/user_registrations_controller.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class UserRegistrationsController < Devise::RegistrationsController
-  helper 'spree/base', 'spree/store'
-
-  include Spree::Core::ControllerHelpers::Auth
-  include Spree::Core::ControllerHelpers::Common
-  include Spree::Core::ControllerHelpers::Order
-  include Spree::Core::ControllerHelpers::Store
-  include Taxonomies
-
-  layout 'storefront'
-
   before_action :check_permissions, only: [:edit, :update]
   skip_before_action :require_no_authentication
 

--- a/templates/app/controllers/user_sessions_controller.rb
+++ b/templates/app/controllers/user_sessions_controller.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class UserSessionsController < Devise::SessionsController
-  helper 'spree/base', 'spree/store'
-
-  include Spree::Core::ControllerHelpers::Auth
-  include Spree::Core::ControllerHelpers::Common
-  include Spree::Core::ControllerHelpers::Order
-  include Spree::Core::ControllerHelpers::Store
-  include Taxonomies
-
-  layout 'storefront'
-
   # This is included in ControllerHelpers::Order.  We just want to call
   # it after someone has successfully logged in.
   after_action :set_current_order, only: :create


### PR DESCRIPTION
Goal
----

As a maintainer of SolidusStarterFrontend,
I want to extract StoreDeviseController from the DeviseController-based controllers 
So that we can remove the boilerplate code from the controllers

Background
----------

Suggested by @elia in <https://github.com/solidusio/solidus_starter_frontend/pull/243#discussion_r974277048>.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
~- [ ] Bug fix (non-breaking change which fixes an issue)~
~- [ ] New feature (non-breaking change which adds functionality)~
~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
~- [ ] My change requires a change to the documentation.~
~- [ ] I have updated the documentation accordingly.~
