### PR TITLE
Alert user when TOS not checked

### DIFF
--- a/templates/app/assets/javascripts/checkout.js
+++ b/templates/app/assets/javascripts/checkout.js
@@ -18,17 +18,18 @@ window.addEventListener('DOMContentLoaded', () => {
   const termsCheckbox = document.getElementById('accept_terms_and_conditions');
 
   if (termsCheckbox) {
-    termsCheckbox.addEventListener('change', () => {
-      const submitButton = termsCheckbox.closest('form')
-        .querySelector('[type="submit"]');
-
+    const form = termsCheckbox.closest('form');
+    const submitButton = form.querySelector('[type="submit"]');
+    form.onsubmit = function () {
       if (termsCheckbox.checked) {
+        submitButton.innerHTML = 'Submitting...';
+        return true;
+      } else {
+        alert('Please review and accept the Terms of Service');
         submitButton.removeAttribute('disabled');
         submitButton.classList.remove('disabled');
-      } else {
-        submitButton.setAttribute('disabled', true);
-        submitButton.classList.add('disabled');
-      }
-    });
-  }
+        return false;
+      };
+    }; 
+  };
 });

--- a/templates/app/views/checkout/steps/_confirm_step.html.erb
+++ b/templates/app/views/checkout/steps/_confirm_step.html.erb
@@ -17,7 +17,6 @@
     I18n.t('spree.place_order'),
     class: 'button-primary',
     name: :commit,
-    disabled: true
   ) %>
 </div>
 

--- a/templates/spec/system/address_spec.rb
+++ b/templates/spec/system/address_spec.rb
@@ -62,10 +62,10 @@ RSpec.describe 'Address', type: :system, inaccessible: true do
           page.find(@state_name_css).set('Toscana')
 
           select france.name, from: 'Country'
-
-          expect(page).to have_no_css(@state_name_css)
-          expect(page).to have_no_css(@state_select_css)
         end
+
+        expect(page).to have_no_css(@state_name_css)
+        expect(page).to have_no_css(@state_select_css)
       end
     end
   end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -297,13 +297,16 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       order.payments << create(:payment)
       visit checkout_state_path(:confirm)
 
+      # Test TOS not checked alert
+      accept_alert('Please review and accept the Terms of Service') { click_button "Place Order" }
+
       # prevent form submit to verify button is disabled
       page.execute_script("document.getElementById('checkout_form_confirm').onsubmit = function(){return false;}")
 
       check 'Agree to Terms of Service'
-      expect(page).not_to have_selector('button.button-primary[disabled]')
       click_button "Place Order"
-      expect(page).to have_selector('button.button-primary[disabled]')
+      button = find('button.button-primary')
+      expect(button).to be_disabled
     end
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a simple alert for the user if they have not checked the ToS box on the order confirmation page.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you place an order on the starter frontend, you need to check the "Agree to Terms of Service" checkbox before being able to proceed with the "Place Order" submit button.

If you just forget to check it, the "Place Order" button doesn't work but no error is rendered to the user.
We expect an informative message to be rendered to the user so they can see why they cannot submit the form.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Appended steps to a test to click on "place order" prior to accepting ToS and then accepting the alert. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
