### PR TITLE
Convert cart routes to resource routes

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -168,9 +168,8 @@ def install_routes
       resources :coupon_codes, only: :create
     end
 
-    resource :order, as: :cart, only: ['edit']
+    resource :cart, controller: 'orders', only: ['edit', 'update']
 
-    patch '/cart', to: 'orders#update', as: :update_cart
     put '/cart/empty', to: 'orders#empty', as: :empty_cart
 
     # route globbing for pretty nested taxon and product paths

--- a/template.rb
+++ b/template.rb
@@ -168,9 +168,11 @@ def install_routes
       resources :coupon_codes, only: :create
     end
 
-    resource :cart, controller: 'orders', only: ['edit', 'update']
-
-    put '/cart/empty', to: 'orders#empty', as: :empty_cart
+    resource :cart, controller: 'orders', only: ['edit', 'update'] do
+      member do
+        put 'empty'
+      end
+    end
 
     # route globbing for pretty nested taxon and product paths
     get '/t/*id', to: 'taxons#show', as: :nested_taxons

--- a/template.rb
+++ b/template.rb
@@ -168,7 +168,8 @@ def install_routes
       resources :coupon_codes, only: :create
     end
 
-    get '/cart', to: 'orders#edit', as: :cart
+    resource :order, as: :cart, only: ['edit']
+
     patch '/cart', to: 'orders#update', as: :update_cart
     put '/cart/empty', to: 'orders#empty', as: :empty_cart
 

--- a/templates/app/components/link_to_cart_component.rb
+++ b/templates/app/components/link_to_cart_component.rb
@@ -4,7 +4,7 @@ class LinkToCartComponent < ViewComponent::Base
   delegate :current_order, :spree, to: :helpers
 
   def call
-    link_to text.html_safe, cart_path, class: "cart-info #{css_class}", title: 'Cart'
+    link_to text.html_safe, edit_cart_path, class: "cart-info #{css_class}", title: 'Cart'
   end
 
   private

--- a/templates/app/controllers/checkout_controller.rb
+++ b/templates/app/controllers/checkout_controller.rb
@@ -148,7 +148,7 @@ class CheckoutController < StoreController
 
   def load_order
     @order = current_order
-    redirect_to(cart_path) && return unless @order
+    redirect_to(edit_cart_path) && return unless @order
   end
 
   # Allow the customer to only go back or stay on the current state
@@ -164,19 +164,19 @@ class CheckoutController < StoreController
 
   def ensure_checkout_allowed
     unless @order.checkout_allowed?
-      redirect_to cart_path
+      redirect_to edit_cart_path
     end
   end
 
   def ensure_order_not_completed
-    redirect_to cart_path if @order.completed?
+    redirect_to edit_cart_path if @order.completed?
   end
 
   def ensure_sufficient_stock_lines
     if @order.insufficient_stock_lines.present?
       out_of_stock_items = @order.insufficient_stock_lines.collect(&:name).to_sentence
       flash[:error] = t('spree.inventory_error_flash_for_insufficient_quantity', names: out_of_stock_items)
-      redirect_to cart_path
+      redirect_to edit_cart_path
     end
   end
 
@@ -226,7 +226,7 @@ class CheckoutController < StoreController
     packages = @order.shipments.map(&:to_package)
     if packages.empty?
       flash[:error] = I18n.t('spree.insufficient_stock_for_order')
-      redirect_to cart_path
+      redirect_to edit_cart_path
     else
       availability_validator = Spree::Stock::AvailabilityValidator.new
       unavailable_items = @order.line_items.reject { |line_item| availability_validator.validate(line_item) }

--- a/templates/app/controllers/coupon_codes_controller.rb
+++ b/templates/app/controllers/coupon_codes_controller.rb
@@ -19,7 +19,7 @@ class CouponCodesController < StoreController
             flash[:error] = handler.error
           end
 
-          redirect_back fallback_location: cart_path
+          redirect_back fallback_location: edit_cart_path
         end
       end
     end

--- a/templates/app/controllers/order_contents_controller.rb
+++ b/templates/app/controllers/order_contents_controller.rb
@@ -33,7 +33,7 @@ class OrderContentsController < StoreController
           redirect_back_or_default(root_path)
           return
         else
-          redirect_to cart_path
+          redirect_to edit_cart_path
         end
       end
     end

--- a/templates/app/controllers/orders_controller.rb
+++ b/templates/app/controllers/orders_controller.rb
@@ -53,6 +53,8 @@ class OrdersController < StoreController
     redirect_to cart_path
   end
 
+  private
+
   def accurate_title
     if @order && @order.completed?
       t('spree.order_number', number: @order.number)
@@ -60,8 +62,6 @@ class OrdersController < StoreController
       t('spree.shopping_cart')
     end
   end
-
-  private
 
   def store_guest_token
     cookies.permanent.signed[:guest_token] = params[:token] if params[:token]

--- a/templates/app/controllers/orders_controller.rb
+++ b/templates/app/controllers/orders_controller.rb
@@ -25,7 +25,7 @@ class OrdersController < StoreController
           if params.key?(:checkout)
             redirect_to checkout_state_path(@order.checkout_steps.first)
           else
-            redirect_to cart_path
+            redirect_to edit_cart_path
           end
         end
       end
@@ -40,7 +40,7 @@ class OrdersController < StoreController
     authorize! :edit, @order, cookies.signed[:guest_token]
     if params[:id] && @order.number != params[:id]
       flash[:error] = t('spree.cannot_edit_orders')
-      redirect_to cart_path
+      redirect_to edit_cart_path
     end
   end
 
@@ -50,7 +50,7 @@ class OrdersController < StoreController
       @order.empty!
     end
 
-    redirect_to cart_path
+    redirect_to edit_cart_path
   end
 
   private

--- a/templates/app/controllers/store_controller.rb
+++ b/templates/app/controllers/store_controller.rb
@@ -26,6 +26,6 @@ class StoreController < Spree::BaseController
     Spree::OrderMutex.with_lock!(@order) { yield }
   rescue Spree::OrderMutex::LockFailed
     flash[:error] = t('spree.order_mutex_error')
-    redirect_to cart_path
+    redirect_to edit_cart_path
   end
 end

--- a/templates/app/views/layouts/_top_bar.html.erb
+++ b/templates/app/views/layouts/_top_bar.html.erb
@@ -15,7 +15,7 @@
 
   <div class="cart-link" id="link-to-cart">
     <noscript>
-      <%= link_to t('spree.cart'), cart_path %>
+      <%= link_to t('spree.cart'), edit_cart_path %>
     </noscript>
   </div>
 

--- a/templates/app/views/orders/edit.html.erb
+++ b/templates/app/views/orders/edit.html.erb
@@ -4,7 +4,7 @@
   <% if @order.line_items.empty? %>
     <%= render 'cart_empty' %>
   <% else %>
-    <%= form_for @order, url: update_cart_path, html: {id: 'update-cart'} do |order_form| %>
+    <%= form_for @order, url: cart_path, method: 'patch', html: {id: 'update-cart'} do |order_form| %>
       <% order = order_form.object %>
       <%= render 'cart_header', order_form: order_form %>
       <%= render 'shared/error_messages', target: order %>

--- a/templates/spec/requests/checkout_spec.rb
+++ b/templates/spec/requests/checkout_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe 'Checkout', type: :request, with_signed_in_user: true do
       order.line_items.destroy_all
       get checkout_path, params: { state: "delivery" }
 
-      expect(response).to redirect_to(cart_path)
+      expect(response).to redirect_to(edit_cart_path)
     end
 
     it "redirects to the cart path if current_order is nil" do
       order.destroy
       get checkout_path, params: { state: "delivery" }
 
-      expect(response).to redirect_to(cart_path)
+      expect(response).to redirect_to(edit_cart_path)
     end
 
     it "redirects to cart if order is completed" do
       order.touch(:completed_at)
       get checkout_path, params: { state: "address" }
 
-      expect(response).to redirect_to(cart_path)
+      expect(response).to redirect_to(edit_cart_path)
     end
 
     # Regression test for https://github.com/spree/spree/issues/2280
@@ -304,7 +304,7 @@ RSpec.describe 'Checkout', type: :request, with_signed_in_user: true do
       it "renders the edit template" do
         order.line_items.destroy_all
         patch update_checkout_path(state: "address", order: { bill_address_attributes: address_params })
-        expect(response).to redirect_to(cart_path)
+        expect(response).to redirect_to(edit_cart_path)
       end
     end
 
@@ -312,9 +312,9 @@ RSpec.describe 'Checkout', type: :request, with_signed_in_user: true do
       let(:user) { create(:user) }
       let(:order) { create(:order_with_line_items, guest_token: nil, user_id: nil) }
 
-      it "redirects to the cart_path" do
+      it "redirects to the edit_cart_path" do
         patch update_checkout_path(state: "confirm")
-        expect(response).to redirect_to cart_path
+        expect(response).to redirect_to edit_cart_path
       end
     end
 
@@ -393,7 +393,7 @@ RSpec.describe 'Checkout', type: :request, with_signed_in_user: true do
         it "redirects the customer to the cart page with an error message" do
           patch update_checkout_path(state: "address", order: { bill_address_attributes: address_params })
           expect(flash[:error]).to eq(I18n.t('spree.insufficient_stock_for_order'))
-          expect(response).to redirect_to(cart_path)
+          expect(response).to redirect_to(edit_cart_path)
         end
       end
 
@@ -434,7 +434,7 @@ RSpec.describe 'Checkout', type: :request, with_signed_in_user: true do
       end
 
       it "redirects to cart" do
-        expect(response).to redirect_to cart_path
+        expect(response).to redirect_to edit_cart_path
       end
 
       it "redirects set flash message for no inventory" do

--- a/templates/spec/requests/order_contents_spec.rb
+++ b/templates/spec/requests/order_contents_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Order Contents', type: :request do
         expect do
           post order_contents_path, params: { variant_id: variant.id, quantity: 5 }
         end.to change { user.orders.count }.by(1)
-        expect(response).to redirect_to cart_path
+        expect(response).to redirect_to edit_cart_path
         order = user.orders.first
         expect(order.line_items.size).to eq(1)
         line_item = order.line_items.first
@@ -57,7 +57,7 @@ RSpec.describe 'Order Contents', type: :request do
             post order_contents_path, params: { variant_id: variant.id, quantity: '' }
           end.to change { Spree::Order.count }.by(1)
           order = Spree::Order.last
-          expect(response).to redirect_to cart_path
+          expect(response).to redirect_to edit_cart_path
           expect(order.line_items.size).to eq(1)
           line_item = order.line_items.first
           expect(line_item.variant_id).to eq(variant.id)
@@ -71,7 +71,7 @@ RSpec.describe 'Order Contents', type: :request do
             post order_contents_path, params: { variant_id: variant.id, quantity: nil }
           end.to change { Spree::Order.count }.by(1)
           order = Spree::Order.last
-          expect(response).to redirect_to cart_path
+          expect(response).to redirect_to edit_cart_path
           expect(order.line_items.size).to eq(1)
           line_item = order.line_items.first
           expect(line_item.variant_id).to eq(variant.id)

--- a/templates/spec/requests/orders_ability_spec.rb
+++ b/templates/spec/requests/orders_ability_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Order permissions', type: :request do
 
     context '#edit' do
       it 'checks if user is authorized for :read' do
-        get cart_path
+        get edit_cart_path
         expect(response).to redirect_to(login_path)
       end
     end

--- a/templates/spec/requests/orders_spec.rb
+++ b/templates/spec/requests/orders_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Order', type: :request do
           get edit_order_path(other_order.number)
 
           expect(flash[:error]).to eq "You may only edit your current shopping cart."
-          expect(response).to redirect_to cart_path
+          expect(response).to redirect_to edit_cart_path
         end
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe 'Order', type: :request do
       let(:user) { create(:user) }
 
       it "builds a new valid order with complete meta-data" do
-        get cart_path
+        get edit_cart_path
 
         order = assigns[:order]
 
@@ -61,7 +61,7 @@ RSpec.describe 'Order', type: :request do
 
       it "redirects to cart path (on success)" do
         put order_path(order.number), params: { order: { email: 'test@email.com' } }
-        expect(response).to redirect_to(cart_path)
+        expect(response).to redirect_to(edit_cart_path)
       end
 
       it "advances the order if :checkout button is pressed" do
@@ -89,7 +89,7 @@ RSpec.describe 'Order', type: :request do
     it "destroys line items in the current order" do
       put empty_cart_path
 
-      expect(response).to redirect_to(cart_path)
+      expect(response).to redirect_to(edit_cart_path)
       expect(order.reload.line_items).to be_blank
     end
   end

--- a/templates/spec/system/cart_spec.rb
+++ b/templates/spec/system/cart_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Cart', type: :system, inaccessible: true do
       visit product_path(product)
       click_button "add-to-cart-button"
 
-      visit cart_path
+      visit edit_cart_path
       expect(page).to have_content(product.name)
     end
   end

--- a/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
+++ b/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Checkout confirm page submission', :js, type: :system do
           check 'Agree to Terms of Service'
           click_button "Place Order"
           expect(page).to have_content "#{order_product.name} became unavailable"
-          expect(page).to have_current_path cart_path
+          expect(page).to have_current_path edit_cart_path
         end
       end
     end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
 
     context "and updates line item quantity and try to reach payment page" do
       before do
-        visit cart_path
+        visit edit_cart_path
         within '.cart-item__quantity' do
           fill_in first("input")["name"], with: 3
         end

--- a/templates/spec/system/coupon_code_spec.rb
+++ b/templates/spec/system/coupon_code_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Coupon code promotions', type: :system, js: true do
         end
 
         specify do
-          visit cart_path
+          visit edit_cart_path
 
           fill_in "coupon_code", with: "onetwo"
           click_button "Apply Code"
@@ -193,7 +193,7 @@ RSpec.describe 'Coupon code promotions', type: :system, js: true do
           click_link "Spree Mug"
           click_button "add-to-cart-button"
 
-          visit cart_path
+          visit edit_cart_path
           fill_in "coupon_code", with: "onetwo"
           click_button "Apply Code"
 
@@ -234,7 +234,7 @@ RSpec.describe 'Coupon code promotions', type: :system, js: true do
           click_link "Spree Mug"
           click_button "add-to-cart-button"
 
-          visit cart_path
+          visit edit_cart_path
 
           within '.cart-footer__total' do
             expect(page).to have_content("$30.00")


### PR DESCRIPTION
Goal
----

As a SolidusStarterFrontend maintainer
I want the cart routes to be converted from custom routes to resource routes
So that they will be consistent with Rails conventions which will make them more maintainable in the long run.

What about converting `OrdersController#empty` into a CRUD resource action?
---------------------------------------------------------------------------

I think `OrdersController#empty` is okay as it is. It defines a clear, specific action for the Order resource: it empties the current order (the cart).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
~- [ ] Bug fix (non-breaking change which fixes an issue)~
~- [ ] New feature (non-breaking change which adds functionality)~
~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
~- [ ] My change requires a change to the documentation.~
~- [ ] I have updated the documentation accordingly.~
