### PR TITLE
Remove Empty Cart feature

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -180,7 +180,6 @@ with_log['installing routes'] do
 
     get '/cart', to: 'orders#edit', as: :cart
     patch '/cart', to: 'orders#update', as: :update_cart
-    put '/cart/empty', to: 'orders#empty', as: :empty_cart
 
     # route globbing for pretty nested taxon and product paths
     get '/t/*id', to: 'taxons#show', as: :nested_taxons

--- a/templates/app/assets/stylesheets/components/cart/_cart_secondary_actions.scss
+++ b/templates/app/assets/stylesheets/components/cart/_cart_secondary_actions.scss
@@ -19,7 +19,6 @@
     }
 
     &::after {
-      content: "or";
       margin-right: .5rem;
     }
 

--- a/templates/app/controllers/orders_controller.rb
+++ b/templates/app/controllers/orders_controller.rb
@@ -44,15 +44,6 @@ class OrdersController < StoreController
     end
   end
 
-  def empty
-    if @order = current_order
-      authorize! :update, @order, cookies.signed[:guest_token]
-      @order.empty!
-    end
-
-    redirect_to cart_path
-  end
-
   def accurate_title
     if @order && @order.completed?
       t('spree.order_number', number: @order.number)

--- a/templates/app/views/orders/_cart_secondary_actions.html.erb
+++ b/templates/app/views/orders/_cart_secondary_actions.html.erb
@@ -2,14 +2,4 @@
   <div class="cart-secondary-actions__continue">
     <%= link_to t('spree.continue_shopping'), products_path %>
   </div>
-
-  <div class="cart-secondary-actions__empty">
-    <%= form_tag empty_cart_path, method: :put do %>
-      <%= button_tag(
-        t('spree.empty_cart'),
-        class: 'button-inline',
-        name: :commit
-      ) %>
-    <% end %>
-  </div>
 </div>

--- a/templates/spec/requests/orders_ability_spec.rb
+++ b/templates/spec/requests/orders_ability_spec.rb
@@ -28,13 +28,6 @@ RSpec.describe 'Order permissions', type: :request do
       end
     end
 
-    context '#empty' do
-      it 'checks if user is authorized for :update' do
-        put empty_cart_path
-        expect(response).to redirect_to(login_path)
-      end
-    end
-
     context "#show" do
       it "checks against the specified order" do
         get order_path(id: order.number)

--- a/templates/spec/requests/orders_spec.rb
+++ b/templates/spec/requests/orders_spec.rb
@@ -83,17 +83,6 @@ RSpec.describe 'Order', type: :request do
     end
   end
 
-  context "#empty", with_guest_session: true do
-    let(:order) { create(:order_with_line_items, user: nil, store: store) }
-
-    it "destroys line items in the current order" do
-      put empty_cart_path
-
-      expect(response).to redirect_to(cart_path)
-      expect(order.reload.line_items).to be_blank
-    end
-  end
-
   context "when line items quantity is 0", with_guest_session: true do
     let(:order) { create(:order_with_line_items, user: nil, store: store) }
     let(:line_item) { order.line_items.first }

--- a/templates/spec/system/cart_spec.rb
+++ b/templates/spec/system/cart_spec.rb
@@ -40,21 +40,6 @@ RSpec.describe 'Cart', type: :system, inaccessible: true do
     end
   end
 
-  it 'allows you to empty the cart', js: true do
-    create(:product, name: "RoR Mug")
-    visit root_path
-    click_link "RoR Mug"
-    click_button "add-to-cart-button"
-
-    expect(page).to have_content("RoR Mug")
-    click_on "Empty Cart"
-    expect(page).to have_content("Your cart is empty")
-
-    within "#link-to-cart" do
-      expect(page.text).to eq('')
-    end
-  end
-
   # regression for https://github.com/spree/spree/issues/2276
   context "product contains variants but no option values" do
     let(:variant) { create(:variant) }


### PR DESCRIPTION
Goal
----

As a maintainer of SolidusStarterFrontend
I want to remove the Empty Cart function
So that we won't have to maintain a secondary function that's not critical to the app
And we won't have to keep the custom route for that function

Background
----------

This is part of an epic to make the order and checkout routes more resourceful. 

This will be the planned outcome of that epic:

![image](https://user-images.githubusercontent.com/61476/193782161-9f44006b-90b5-4d57-a21c-188ce060142b.png)

This is a 15 minute video explaining the epic: https://www.loom.com/share/c384938b2d224ebfaff03b0f0cf2d311. 

Note that this was recorded before we decided to remove the Empty Cart feature function altogether.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
