### PR TITLE
Make checkout routes more resource-oriented

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -168,10 +168,7 @@ with_log['installing routes'] do
     resource :checkout_session, only: :new
     resource :checkout_guest_session, only: :create
 
-    resource :checkout, only: :edit
-
-    # non-restful checkout stuff
-    patch '/checkout/update/:state', to: 'checkouts#update', as: :update_checkout
+    resource :checkout, only: [:edit, :update]
 
     get '/orders/:id/token/:token' => 'orders#show', as: :token_order
 

--- a/template.rb
+++ b/template.rb
@@ -172,7 +172,6 @@ with_log['installing routes'] do
 
     # non-restful checkout stuff
     patch '/checkout/update/:state', to: 'checkouts#update', as: :update_checkout
-    get '/checkout/:state', to: 'checkouts#edit', as: :checkout_state
 
     get '/orders/:id/token/:token' => 'orders#show', as: :token_order
 

--- a/template.rb
+++ b/template.rb
@@ -168,10 +168,11 @@ with_log['installing routes'] do
     resource :checkout_session, only: :new
     resource :checkout_guest_session, only: :create
 
+    resource :checkout, only: :edit
+
     # non-restful checkout stuff
     patch '/checkout/update/:state', to: 'checkouts#update', as: :update_checkout
     get '/checkout/:state', to: 'checkouts#edit', as: :checkout_state
-    get '/checkout', to: 'checkouts#edit', as: :checkout
 
     get '/orders/:id/token/:token' => 'orders#show', as: :token_order
 

--- a/templates/app/controllers/carts_controller.rb
+++ b/templates/app/controllers/carts_controller.rb
@@ -28,7 +28,7 @@ class CartsController < StoreController
       respond_with(@order) do |format|
         format.html do
           if params.key?(:checkout)
-            redirect_to checkout_state_path(@order.checkout_steps.first)
+            redirect_to edit_checkout_path(state: @order.checkout_steps.first)
           else
             redirect_to edit_cart_path
           end

--- a/templates/app/controllers/checkout_base_controller.rb
+++ b/templates/app/controllers/checkout_base_controller.rb
@@ -11,7 +11,7 @@ class CheckoutBaseController < StoreController
 
   before_action :check_authorization
 
-  helper 'orders', 'spree/checkout'
+  helper 'orders', 'checkout'
 
   rescue_from Spree::Core::GatewayError, with: :rescue_from_spree_gateway_error
   rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error

--- a/templates/app/controllers/checkout_base_controller.rb
+++ b/templates/app/controllers/checkout_base_controller.rb
@@ -29,7 +29,7 @@ class CheckoutBaseController < StoreController
   # truthy).
   def ensure_order_is_not_skipping_states
     if params[:state]
-      redirect_to checkout_state_path(@order.state) if @order.can_go_to_state?(params[:state]) && !skip_state_validation?
+      redirect_to edit_checkout_path(state: @order.state) if @order.can_go_to_state?(params[:state]) && !skip_state_validation?
       @order.state = params[:state]
     end
   end
@@ -70,7 +70,7 @@ class CheckoutBaseController < StoreController
         item_names = unavailable_items.map(&:name).to_sentence
         flash[:error] = t('spree.inventory_error_flash_for_insufficient_shipment_quantity', unavailable_items: item_names)
         @order.restart_checkout_flow
-        redirect_to checkout_state_path(@order.state)
+        redirect_to edit_checkout_path(state: @order.state)
       end
     end
   end

--- a/templates/app/controllers/checkout_guest_sessions_controller.rb
+++ b/templates/app/controllers/checkout_guest_sessions_controller.rb
@@ -3,7 +3,7 @@
 class CheckoutGuestSessionsController < CheckoutBaseController
   def create
     if params[:order][:email] =~ Devise.email_regexp && current_order.update(email: params[:order][:email])
-      redirect_to checkout_path
+      redirect_to edit_checkout_path
     else
       flash[:registration_error] = t(:email_is_invalid, scope: [:errors, :messages])
       @user = Spree::User.new

--- a/templates/app/controllers/checkouts_controller.rb
+++ b/templates/app/controllers/checkouts_controller.rb
@@ -43,7 +43,7 @@ class CheckoutsController < CheckoutBaseController
 
   def redirect_on_failure
     flash[:error] = @order.errors.full_messages.join("\n")
-    redirect_to(checkout_state_path(@order.state))
+    redirect_to(edit_checkout_path(state: @order.state))
   end
 
   def transition_forward
@@ -66,7 +66,7 @@ class CheckoutsController < CheckoutBaseController
   end
 
   def send_to_next_state
-    redirect_to checkout_state_path(@order.state)
+    redirect_to edit_checkout_path(state: @order.state)
   end
 
   def update_params
@@ -105,7 +105,7 @@ class CheckoutsController < CheckoutBaseController
       if (params[:state] && !@order.has_checkout_step?(params[:state])) ||
          (!params[:state] && !@order.has_checkout_step?(@order.state))
         @order.state = 'cart'
-        redirect_to checkout_state_path(@order.checkout_steps.first)
+        redirect_to edit_checkout_path(state: @order.checkout_steps.first)
       end
     end
 
@@ -113,7 +113,7 @@ class CheckoutsController < CheckoutBaseController
     # If confirmation of payment fails, redirect back to payment screen
     if params[:state] == "confirm" && @order.payment_required? && @order.payments.valid.empty?
       flash.keep
-      redirect_to checkout_state_path("payment")
+      redirect_to edit_checkout_path(state: "payment")
     end
   end
 

--- a/templates/app/helpers/checkout_helper.rb
+++ b/templates/app/helpers/checkout_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CheckoutHelper
+  def checkout_states
+    @order.checkout_steps
+  end
+
+  def checkout_progress
+    states = checkout_states
+    items = states.map do |state|
+      text = I18n.t("spree.order_state.#{state}").titleize
+
+      css_classes = []
+      current_index = states.index(@order.state)
+      state_index = states.index(state)
+
+      if state_index < current_index
+        css_classes << 'completed'
+        text = link_to text, checkout_state_path(state)
+      end
+
+      css_classes << 'next' if state_index == current_index + 1
+      css_classes << 'current' if state == @order.state
+      css_classes << 'first' if state_index == 0
+      css_classes << 'last' if state_index == states.length - 1
+      # It'd be nice to have separate classes but combining them with a dash helps out for IE6 which only sees the last class
+      content_tag('li', content_tag('span', text), class: css_classes.join('-'))
+    end
+    content_tag('ol', raw(items.join("\n")), class: 'progress-steps', id: "checkout-step-#{@order.state}")
+  end
+end

--- a/templates/app/helpers/checkout_helper.rb
+++ b/templates/app/helpers/checkout_helper.rb
@@ -16,7 +16,7 @@ module CheckoutHelper
 
       if state_index < current_index
         css_classes << 'completed'
-        text = link_to text, checkout_state_path(state)
+        text = link_to text, edit_checkout_path(state: state)
       end
 
       css_classes << 'next' if state_index == current_index + 1

--- a/templates/app/views/checkouts/_checkout_step.html.erb
+++ b/templates/app/views/checkouts/_checkout_step.html.erb
@@ -1,4 +1,4 @@
-<%= form_for order, url: update_checkout_path(order.state), html: { id: "checkout_form_#{order.state}" } do |form| %>
+<%= form_for order, url: checkout_path(state: order.state), html: { id: "checkout_form_#{order.state}" } do |form| %>
   <% if order.state == "address" || !order.email? %>
     <div class="text-input">
       <%= form.label :email, 'Customer E-Mail:' %>

--- a/templates/app/views/orders/_address_overview.html.erb
+++ b/templates/app/views/orders/_address_overview.html.erb
@@ -5,7 +5,7 @@
 
   <%= link_to(
     "[#{t('spree.actions.edit')}]",
-    checkout_state_path(:address),
+    edit_checkout_path(state: :address),
     { class: 'address-overview__edit' }
   ) unless @order.completed? %>
 

--- a/templates/app/views/orders/_order_shipments.html.erb
+++ b/templates/app/views/orders/_order_shipments.html.erb
@@ -5,7 +5,7 @@
 
   <%= link_to(
     "[#{t('spree.actions.edit')}]",
-    checkout_state_path(:delivery),
+    edit_checkout_path(state: :delivery),
     { class: 'order-shipments__edit' }
   ) unless @order.completed? %>
 

--- a/templates/app/views/orders/_payment_info.html.erb
+++ b/templates/app/views/orders/_payment_info.html.erb
@@ -5,7 +5,7 @@
 
   <%= link_to(
     "[#{t('spree.actions.edit')}]",
-    checkout_state_path(:payment),
+    edit_checkout_path(state: :payment),
     { class: 'payment-info__edit' }
   ) unless @order.completed? %>
 

--- a/templates/spec/controllers/checkout_guest_sessions_controller_spec.rb
+++ b/templates/spec/controllers/checkout_guest_sessions_controller_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe CheckoutGuestSessionsController, type: :controller do
       subject
     end
 
-    it 'redirects to the checkout_path after saving' do
+    it 'redirects to the edit_checkout_path after saving' do
       subject
-      expect(response).to redirect_to checkout_path
+      expect(response).to redirect_to edit_checkout_path
     end
 
     # Regression test for https://github.com/solidusio/solidus/issues/1588
@@ -48,7 +48,7 @@ RSpec.describe CheckoutGuestSessionsController, type: :controller do
         expect {
           subject
         }.not_to change { Spree::Address.count }
-        expect(response).to redirect_to checkout_path
+        expect(response).to redirect_to edit_checkout_path
       end
     end
 

--- a/templates/spec/requests/carts_spec.rb
+++ b/templates/spec/requests/carts_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Cart', type: :request do
           patch cart_path, params: { checkout: true }
         end.to change { order.reload.state }.from('cart').to('address')
 
-        expect(response).to redirect_to checkout_state_path('address')
+        expect(response).to redirect_to edit_checkout_path(state: 'address')
       end
     end
   end

--- a/templates/spec/requests/checkout_with_views_spec.rb
+++ b/templates/spec/requests/checkout_with_views_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Checkout view rendering', type: :request, with_signed_in_user: t
       end
 
       it "displays rate cost in correct currency" do
-        get checkout_path
+        get edit_checkout_path
         html = Nokogiri::HTML(response.body)
         expect(html.css('.shipping-methods__rate').text.strip).to include("£10")
       end

--- a/templates/spec/requests/checkouts_spec.rb
+++ b/templates/spec/requests/checkouts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
     let!(:order) { create(:order_with_line_items) }
 
     it 'checks if the user is authorized for :edit' do
-      get checkout_path, params: { state: "address" }
+      get edit_checkout_path, params: { state: "address" }
 
       expect(assigns[:order]).to eq order
       expect(status).to eq(200)
@@ -23,21 +23,21 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
 
     it "redirects to the cart path if checkout_allowed? return false" do
       order.line_items.destroy_all
-      get checkout_path, params: { state: "delivery" }
+      get edit_checkout_path, params: { state: "delivery" }
 
       expect(response).to redirect_to(edit_cart_path)
     end
 
     it "redirects to the cart path if current_order is nil" do
       order.destroy
-      get checkout_path, params: { state: "delivery" }
+      get edit_checkout_path, params: { state: "delivery" }
 
       expect(response).to redirect_to(edit_cart_path)
     end
 
     it "redirects to cart if order is completed" do
       order.touch(:completed_at)
-      get checkout_path, params: { state: "address" }
+      get edit_checkout_path, params: { state: "address" }
 
       expect(response).to redirect_to(edit_cart_path)
     end
@@ -46,7 +46,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
     it "redirects to current step trying to access a future step" do
       order.update_column(:state, "address")
 
-      get checkout_path, params: { state: "delivery" }
+      get edit_checkout_path, params: { state: "delivery" }
       expect(response).to redirect_to checkout_state_path("address")
     end
   end
@@ -458,7 +458,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
     end
 
     it "doesn't set a default shipping address on the order" do
-      get checkout_path, params: { state: order.state, order: { bill_address_attributes: address_params } }
+      get edit_checkout_path, params: { state: order.state, order: { bill_address_attributes: address_params } }
       expect(assigns[:order].ship_address).to be_nil
     end
 

--- a/templates/spec/requests/checkouts_spec.rb
+++ b/templates/spec/requests/checkouts_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
       order.update_column(:state, "address")
 
       get edit_checkout_path, params: { state: "delivery" }
-      expect(response).to redirect_to checkout_state_path("address")
+      expect(response).to redirect_to edit_checkout_path(state: "address")
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
 
         it "redirects the next state" do
           post_address
-          expect(response).to redirect_to checkout_state_path("delivery")
+          expect(response).to redirect_to edit_checkout_path(state: "delivery")
         end
 
         context "current_user respond to save address method" do
@@ -348,7 +348,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
         it "due to the order having errors" do
           patch update_checkout_path(state: order.state, order: { bill_address_attributes: address_params })
           expect(flash[:error]).to eq("Valid shipping address required")
-          expect(response).to redirect_to(checkout_state_path('address'))
+          expect(response).to redirect_to(edit_checkout_path(state: 'address'))
         end
       end
 
@@ -362,7 +362,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
         it "redirects due to no available shipping rates for any of the shipments" do
           patch update_checkout_path(state: "address", order: { bill_address_attributes: address_params })
           expect(request.flash.to_h['error']).to eq(I18n.t('spree.items_cannot_be_shipped'))
-          expect(response).to redirect_to(checkout_state_path('address'))
+          expect(response).to redirect_to(edit_checkout_path(state: 'address'))
         end
       end
     end
@@ -412,7 +412,7 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
             patch update_checkout_path(state: "address", order: { bill_address_attributes: address_params })
             error = I18n.t('spree.inventory_error_flash_for_insufficient_shipment_quantity', unavailable_items: order.products.first.name)
             expect(flash[:error]).to eq(error)
-            expect(response).to redirect_to(checkout_state_path(state: :address))
+            expect(response).to redirect_to(edit_checkout_path(state: :address))
           end
         end
       end

--- a/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
+++ b/templates/spec/system/checkout_confirm_insufficient_stock_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Checkout confirm page submission', :js, type: :system do
     context 'when there are not other backorderable stock locations' do
       context 'when the customer is on the confirm page and the availabilty drops to zero' do
         before do
-          visit checkout_state_path(:confirm)
+          visit edit_checkout_path(state: :confirm)
           order_stock_item.set_count_on_hand(0)
           order.line_items.first.variant.stock_items.reload
         end
@@ -44,7 +44,7 @@ RSpec.describe 'Checkout confirm page submission', :js, type: :system do
 
       context 'when the customer is on the confirm page and the availabilty drops to zero' do
         before do
-          visit checkout_state_path(:confirm)
+          visit edit_checkout_path(state: :confirm)
           order_stock_item.set_count_on_hand(0)
           order.line_items.first.variant.stock_items.reload
         end
@@ -54,19 +54,19 @@ RSpec.describe 'Checkout confirm page submission', :js, type: :system do
           click_button "Place Order"
           error_message = "Quantity selected of #{order_product.name} is not available. Still, items may be available from another stock location, please try again."
           expect(page).to have_content error_message
-          expect(page).to have_current_path checkout_state_path(:address)
+          expect(page).to have_current_path edit_checkout_path(state: :address)
         end
 
         it "can still complete the order using the backorderable stock location by restarting the checkout" do
           check 'Agree to Terms of Service'
           click_button "Place Order"
-          expect(page).to have_current_path checkout_state_path(:address)
+          expect(page).to have_current_path edit_checkout_path(state: :address)
           click_button "Save and Continue"
-          expect(page).to have_current_path checkout_state_path(:delivery)
+          expect(page).to have_current_path edit_checkout_path(state: :delivery)
           click_button "Save and Continue"
-          expect(page).to have_current_path checkout_state_path(:payment)
+          expect(page).to have_current_path edit_checkout_path(state: :payment)
           click_button "Save and Continue"
-          expect(page).to have_current_path checkout_state_path(:confirm)
+          expect(page).to have_current_path edit_checkout_path(state: :confirm)
           check 'Agree to Terms of Service'
           click_button "Place Order"
           expect(page).to have_content 'Your order has been processed successfully'

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
     end
 
     it "does not allow successful order submission" do
-      visit checkout_path
+      visit edit_checkout_path
       order.payments.first.update state: :void
       check 'Agree to Terms of Service'
       click_button 'Place Order'

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
         # We need an order reload here to get newly associated addresses.
         # Then we go back to address where we are supposed to be redirected.
         order.reload
-        visit checkout_state_path(:address)
+        visit edit_checkout_path(state: :address)
       end
 
       context "when user has default addresses saved" do
@@ -178,7 +178,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
           allow_any_instance_of(OrdersController).to receive_messages(spree_current_user: user)
 
           # Simulate redirect back to address after login
-          visit checkout_state_path(:address)
+          visit edit_checkout_path(state: :address)
         end
 
         context "when does not have saved addresses" do
@@ -232,7 +232,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       order.payments.first.update state: :void
       check 'Agree to Terms of Service'
       click_button 'Place Order'
-      expect(page).to have_current_path checkout_state_path(:payment)
+      expect(page).to have_current_path edit_checkout_path(state: :payment)
     end
   end
 
@@ -251,7 +251,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
     end
 
     it "redirects to payment page", inaccessible: true do
-      visit checkout_state_path(:delivery)
+      visit edit_checkout_path(state: :delivery)
       click_button "Save and Continue"
       choose "Credit Card"
       fill_in "Card Number", with: '123'
@@ -261,7 +261,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       check 'Agree to Terms of Service'
       click_button "Place Order"
       expect(page).to have_content("Bogus Gateway: Forced failure")
-      expect(page.current_url).to include("/checkout/payment")
+      expect(page).to have_current_path(edit_checkout_path(state: 'payment'))
     end
   end
 
@@ -284,7 +284,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
     end
 
     it "prevents double clicking the payment button on checkout", js: true do
-      visit checkout_state_path(:payment)
+      visit edit_checkout_path(state: :payment)
 
       # prevent form submit to verify button is disabled
       page.execute_script("document.getElementById('checkout_form_payment').onsubmit = function(){return false;}")
@@ -296,7 +296,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
 
     it "prevents double clicking the confirm button on checkout", js: true do
       order.payments << create(:payment)
-      visit checkout_state_path(:confirm)
+      visit edit_checkout_path(state: :confirm)
 
       # Test TOS not checked alert
       accept_alert('Please review and accept the Terms of Service') { click_button "Place Order" }
@@ -329,7 +329,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       allow_any_instance_of(CheckoutsController).to receive_messages(current_order: order)
       allow_any_instance_of(CheckoutsController).to receive_messages(spree_current_user: order.user)
 
-      visit checkout_state_path(:payment)
+      visit edit_checkout_path(state: :payment)
     end
 
     it "the first payment method should be selected", js: true do
@@ -362,7 +362,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       allow_any_instance_of(CheckoutsController).to receive_messages(spree_current_user: user)
       allow_any_instance_of(OrdersController).to receive_messages(spree_current_user: user)
 
-      visit checkout_state_path(:payment)
+      visit edit_checkout_path(state: :payment)
     end
 
     it "selects first source available and customer moves on" do
@@ -403,7 +403,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       fill_in_address
       click_on "Save and Continue"
       click_on "Save and Continue"
-      expect(page).to have_current_path(checkout_state_path("payment"))
+      expect(page).to have_current_path(edit_checkout_path(state: "payment"))
 
       visit root_path
       click_link bag.name
@@ -431,7 +431,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       fill_in_address
       click_on "Save and Continue"
       click_on "Save and Continue"
-      expect(page).to have_current_path(checkout_state_path("payment"))
+      expect(page).to have_current_path(edit_checkout_path(state: "payment"))
     end
 
     context "and updates line item quantity and try to reach payment page" do
@@ -445,12 +445,12 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       end
 
       it "redirects user back to address step" do
-        visit checkout_state_path("payment")
-        expect(page).to have_current_path(checkout_state_path("address"))
+        visit edit_checkout_path(state: "payment")
+        expect(page).to have_current_path(edit_checkout_path(state: "address"))
       end
 
       it "updates shipments properly through step address -> delivery transitions" do
-        visit checkout_state_path("payment")
+        visit edit_checkout_path(state: "payment")
         click_on "Save and Continue"
         click_on "Save and Continue"
 
@@ -468,12 +468,12 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       end
 
       it "redirects user back to address step" do
-        visit checkout_state_path("payment")
-        expect(page).to have_current_path(checkout_state_path("address"))
+        visit edit_checkout_path(state: "payment")
+        expect(page).to have_current_path(edit_checkout_path(state: "address"))
       end
 
       it "updates shipments properly through step address -> delivery transitions" do
-        visit checkout_state_path("payment")
+        visit edit_checkout_path(state: "payment")
         click_on "Save and Continue"
         click_on "Save and Continue"
 
@@ -498,7 +498,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       click_on "Save and Continue"
 
       click_on "Save and Continue"
-      expect(page).to have_current_path(checkout_state_path("payment"))
+      expect(page).to have_current_path(edit_checkout_path(state: "payment"))
     end
 
     it "applies them & refreshes the page on user clicking the Apply Code button" do
@@ -521,7 +521,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
     context "doesn't fill in coupon code input" do
       it "advances just fine" do
         click_on "Save and Continue"
-        expect(page).to have_current_path(checkout_state_path("confirm"))
+        expect(page).to have_current_path(edit_checkout_path(state: "confirm"))
       end
     end
   end
@@ -548,13 +548,13 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
     end
 
     it "goes right payment step and place order just fine" do
-      expect(page).to have_current_path(checkout_state_path('payment'))
+      expect(page).to have_current_path(edit_checkout_path(state: 'payment'))
 
       choose "Credit Card"
       fill_in_credit_card
       click_button "Save and Continue"
 
-      expect(current_path).to eq checkout_state_path('confirm')
+      expect(page).to have_current_path(edit_checkout_path(state: 'confirm'))
       check 'Agree to Terms of Service'
       click_button "Place Order"
     end
@@ -603,7 +603,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       allow_any_instance_of(OrdersController).to receive_messages(spree_current_user: user)
       allow_any_instance_of(CartLineItemsController).to receive_messages(spree_current_user: user)
 
-      visit checkout_state_path(:delivery)
+      visit edit_checkout_path(state: :delivery)
       click_button "Save and Continue"
       click_button "Save and Continue"
       check 'Agree to Terms of Service'
@@ -634,7 +634,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
 
       it "displays the entered state name without evaluating" do
         add_mug_to_cart
-        visit checkout_state_path(:address)
+        visit edit_checkout_path(state: :address)
 
         # Unlike with the other examples in this spec, calling
         # `checkout_as_guest` in this example causes this example to fail
@@ -657,7 +657,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
         fill_in "Zip", with: "H0H0H0"
 
         click_on 'Save and Continue'
-        visit checkout_state_path(:address)
+        visit edit_checkout_path(state: :address)
 
         expect(page).to have_field(state_name_css, with: xss_string)
       end
@@ -688,7 +688,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       fill_in_credit_card(number: "1")
       click_on "Save and Continue"
 
-      expect(page).to have_current_path("/checkout/confirm")
+      expect(page).to have_current_path(edit_checkout_path(state: 'confirm'))
     end
 
     it "works with card number 4111111111111111", js: true do
@@ -703,7 +703,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       fill_in_credit_card
       click_on "Save and Continue"
 
-      expect(page).to have_current_path("/checkout/confirm")
+      expect(page).to have_current_path(edit_checkout_path(state: 'confirm'))
     end
   end
 

--- a/templates/spec/system/checkout_unshippable_spec.rb
+++ b/templates/spec/system/checkout_unshippable_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'checkout with unshippable items', type: :system, inaccessible: t
   end
 
   it 'displays and removes' do
-    visit checkout_state_path(:delivery)
+    visit edit_checkout_path(state: :delivery)
     expect(page).to have_content('Unshippable Items')
 
     click_button "Save and Continue"


### PR DESCRIPTION
## Goal

As a SolidusStarterFrontend user
I want the checkout routes to be converted to resource routes
So that they fit better into Rails conventions.

## Background

This is part of an epic to refactor the order and checkout-related controller. Please see https://docs.google.com/spreadsheets/d/1mV2d4H4Ak9kEvc2bxKUpAv4hiz7FwTUE2t-SfOF7g8E/edit?usp=sharing for the list of changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
