### PR TITLE
Move coupon code routes out of order resources

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -172,9 +172,9 @@ with_log['installing routes'] do
 
     get '/orders/:id/token/:token' => 'orders#show', as: :token_order
 
-    resources :orders, only: :show do
-      resources :coupon_codes, only: :create
-    end
+    resources :orders, only: :show
+
+    resources :coupon_codes, only: :create
 
     resource :cart, only: [:edit, :update] do
       put 'empty'

--- a/templates/app/views/orders/_coupon_code.html.erb
+++ b/templates/app/views/orders/_coupon_code.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag order_coupon_codes_path(@order), method: :post, class: "coupon-code" do %>
+<%= form_tag coupon_codes_path, method: :post, class: "coupon-code" do %>
   <div class="coupon-code__input">
     <div class="text-input text-input--small">
       <%= text_field_tag 'coupon_code',


### PR DESCRIPTION
Dependencies
-------------------

This PR can be reviewed because it is no longer expecting additional changes. However, it is set to draft mode until https://github.com/solidusio/solidus_starter_frontend/pull/272 is merged.

Goal
----

As a SolidusStarterFrontend user, I want the coupon code routes moved out of the order resource routes so that we can remove the unnecessary order parameter from the coupon code URL helpers. The coupon codes controller already depends on the current order. 

## Background

This is part of an epic to refactor the order and checkout-related controller. Please see https://docs.google.com/spreadsheets/d/1mV2d4H4Ak9kEvc2bxKUpAv4hiz7FwTUE2t-SfOF7g8E/edit?usp=sharing for the list of changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
