### PR TITLE
Remove token_order route

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -170,8 +170,6 @@ with_log['installing routes'] do
 
     resource :checkout, only: [:edit, :update]
 
-    get '/orders/:id/token/:token' => 'orders#show', as: :token_order
-
     resources :orders, only: :show
 
     resources :coupon_codes, only: :create

--- a/templates/app/controllers/checkouts_controller.rb
+++ b/templates/app/controllers/checkouts_controller.rb
@@ -192,6 +192,6 @@ class CheckoutsController < CheckoutBaseController
   def completion_route
     return order_path(@order) if spree_current_user
 
-    token_order_path(@order, @order.guest_token)
+    order_path(@order, token: @order.guest_token)
   end
 end

--- a/templates/spec/controllers/checkouts_controller_spec.rb
+++ b/templates/spec/controllers/checkouts_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe CheckoutsController, type: :controller do
         it 'redirects to the tokenized order view' do
           request.cookie_jar.signed[:guest_token] = 'ABC'
           post :update, params: { state: 'confirm' }
-          expect(response).to redirect_to token_order_path(order, 'ABC')
+          expect(response).to redirect_to order_path(order, token: 'ABC')
           expect(flash.notice).to eq I18n.t('spree.order_processed_successfully')
         end
       end

--- a/templates/spec/requests/orders_ability_spec.rb
+++ b/templates/spec/requests/orders_ability_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Order permissions', type: :request do
   let(:variant) { create(:variant) }
 
   it 'understands order routes with token' do
-    expect(token_order_path('R123456', 'ABCDEF')).to eq('/orders/R123456/token/ABCDEF')
+    expect(order_path('R123456', token: 'ABCDEF')).to eq('/orders/R123456?token=ABCDEF')
   end
 
   context 'when an order exists in the cookies.signed', with_guest_session: true do

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe 'Checkout', :js, type: :system, inaccessible: true do
       click_on "Place Order"
 
       order = Spree::Order.last
-      expect(page).to have_current_path(token_order_path(order, order.guest_token))
+      expect(page).to have_current_path(order_path(order, token: order.guest_token))
     end
   end
 


### PR DESCRIPTION
## Dependencies

This PR can be reviewed since it is no longer expecting additional changes. However, it is set to draft mode until https://github.com/solidusio/solidus_starter_frontend/pull/273 is merged.

Goal
----

As a SolidusStarterFrontend maintainer
I want to remove the token_order route
So that users of the frontend would have a more minimal set of routes to begin with.

Are there extensions that depend on the token_order_path? 
---------------------------------------------------------

`solidus_auth_devise` calls the path helper but only when the gem is used with the legacy frontend. SolidusStarterFrontend no longer uses `solidus_auth_devise`'s frontend overrides because SolidusStarterFrontend has already embedded them to its code.

Other than that, there are no other known calls to `token_order_path` in Solidus extensions. See

* https://github.com/search?q=org%3Asolidusio+token_order_path&type=code
* https://github.com/search?q=org%3Asolidusio-contrib+token_order_path&type=code

## How Has This Been Tested?

Both automated and manual testing.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/61476/195308505-09ef8803-d827-4adb-8577-53ad7ad4e18e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
