### PR TITLE
Fix `bundle_command` being missing on the Solidus v3.2 installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,56 +101,21 @@ workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs:
-          name: run-specs-with-solidus-3-2-rails-7-ruby-3-1-postgres
-
-      - run-specs:
-          name: run-specs-but-with-solidus-latest
-          solidus_branch: 'master'
-
-      - run-specs:
           name: run-specs-but-with-rails-6
           rails_version: '~> 6.1'
+          solidus_branch: 'v3.2'
 
       - run-specs:
           name: run-specs-but-with-ruby-3-0
           ruby_version: '3.0'
+          solidus_branch: 'v3.2'
 
       - run-specs:
           name: run-specs-but-with-ruby-2
           ruby_version: '2.7'
+          solidus_branch: 'v3.2'
 
       - run-specs:
           name: run-specs-but-with-mysql
           database: 'mysql'
-
-  "Weekly run specs against master":
-    triggers:
-      - schedule:
-          cron: "0 0 * * 4" # every Thursday
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - run-specs:
-          name: run-specs-with-solidus-3-2-rails-7-ruby-3-1-postgres
-
-      - run-specs:
-          name: run-specs-but-with-solidus-latest
-          solidus_branch: 'master'
-
-      - run-specs:
-          name: run-specs-but-with-rails-6
-          rails_version: '~> 6.1'
-
-      - run-specs:
-          name: run-specs-but-with-ruby-3-0
-          ruby_version: '3.0'
-
-      - run-specs:
-          name: run-specs-but-with-ruby-2
-          ruby_version: '2.7'
-
-      - run-specs:
-          name: run-specs-but-with-mysql
-          database: 'mysql'
+          solidus_branch: 'v3.2'

--- a/template.rb
+++ b/template.rb
@@ -5,6 +5,19 @@ with_log = ->(message, &block) {
   block.call
 }
 
+bundle_command = ->(command) do
+  say_status :run, "bundle #{command}"
+  bundle_path = Gem.bin_path("bundler", "bundle")
+
+  BundlerContext.with_original_env do
+    system(
+      Gem.ruby,
+      bundle_path,
+      *command.shellsplit,
+    )
+  end
+end
+
 with_log['checking versions'] do
   if Rails.gem_version < Gem::Version.new('6.1')
     say_status :unsupported, shell.set_color(
@@ -60,7 +73,7 @@ end
 
 with_log['installing gems'] do
   unless Bundler.locked_gems.dependencies['solidus_auth_devise']
-    bundle_command 'add solidus_auth_devise'
+    bundle_command['add solidus_auth_devise']
     generate 'solidus:auth:install'
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The release of Solidus v3.2.3 is broken when using the starter frontend.

Thanks to @stefano-sarioli for reporting this 🙌 

## How Has This Been Tested?

```
# on the v3.2 branch of solidus run:
$ env FRONTEND="$HOME/Code/Nebulab/solidus_starter_frontend/template.rb" bin/sandbox
```


## Screenshots (if appropriate):


![the error](https://user-images.githubusercontent.com/1051/199788748-6dfe8b8f-90fb-49ee-bdbf-df4cd5f3b4bb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
