### PR TITLE
Fix Docker development environment

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -qq \
     sqlite3 \
     libsqlite3-dev \
     chromium \
+    libvips \
   && rm -rf /var/cache/apt/lists/*
 
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \

--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -22,8 +22,6 @@ RUN apt-get update -qq \
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' $PG_VERSION > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8C718D3B5072E1F5 \
- && echo "deb http://repo.mysql.com/apt/debian/ buster mysql-"$MYSQL_VERSION > /etc/apt/sources.list.d/mysql.list
 
 RUN curl -sSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
 
@@ -31,7 +29,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrad
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     libpq-dev \
     postgresql-client-$PG_VERSION \
-    mysql-client \
+    default-mysql-client \
     nodejs \
   &&  rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
         RUBY_VERSION: "2.7.2"
         PG_VERSION: 13
         NODE_VERSION: 14
-        MYSQL_VERSION: "8.0"
         BUNDLER_VERSION: 1.17.3
     image: solidus_starter_frontend-0.1.0
     command: bash -c "(bundle check || bundle) && tail -f /dev/null"


### PR DESCRIPTION
## Description

Fixes Docker development environment.

The installation of mysql-client was broken due to a change in its pub key. We're now using the default-mysql-client instead, which should be compatible.

We're also adding libvips, as it's the backend image processor used on Rails 7. 

## Motivation and Context

We want to keep supporting Docker development environment.

## How Has This Been Tested?

Manually, doing the following through Docker:

- Generating the sandbox application
- Browsing the sandbox application
- Running tests on the sandbox applcation

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
