### PR TITLE
Fix uninitialized constant AppBase when monkey-patching InstallFrontend

### DIFF
--- a/solidus_3_2_patch.rb
+++ b/solidus_3_2_patch.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails/generators'
+require 'rails/generators/app_base'
 require 'generators/solidus/install/install_generator/install_frontend'
 
 module SSFSolidus32Patch


### PR DESCRIPTION
The error is caused by
https://github.com/solidusio/solidus/commit/62ce6f2bc362fa7a2955fbbfb8677685f5ffef41. However, we're making the fix here in SolidusStarterFrontend because the issue only applies to this monkey-patch i.e. it doesn't break Solidus itself. Furthermore, we'll be removing this monkey-patch soon, so this issue will be removed with it.

See https://app.circleci.com/pipelines/github/solidusio/solidus_starter_frontend/1734/workflows/9c4b6afa-c53b-4f61-b449-f6aeb6c35965/jobs/5639 for an instance of this error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
