### PR TITLE
[v3.2] Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3.0
+  slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -72,6 +73,13 @@ commands:
           name: 'Solidus <<parameters.branch>>: Clean up'
           when: always
 
+  notify:
+    steps:
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: main, v[0-9]+\.[0-9]+
+
 jobs:
   run-specs:
     executor:
@@ -83,6 +91,7 @@ jobs:
           branch: <<parameters.solidus_branch>>
           rails_version: <<parameters.rails_version>>
       - solidusio_extensions/store-test-results
+      - notify
     parameters:
       solidus_branch:
         type: string
@@ -101,21 +110,25 @@ workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs:
+          context: slack-secrets
           name: run-specs-but-with-rails-6
           rails_version: '~> 6.1'
           solidus_branch: 'v3.2'
 
       - run-specs:
+          context: slack-secrets
           name: run-specs-but-with-ruby-3-0
           ruby_version: '3.0'
           solidus_branch: 'v3.2'
 
       - run-specs:
+          context: slack-secrets
           name: run-specs-but-with-ruby-2
           ruby_version: '2.7'
           solidus_branch: 'v3.2'
 
       - run-specs:
+          context: slack-secrets
           name: run-specs-but-with-mysql
           database: 'mysql'
           solidus_branch: 'v3.2'


### PR DESCRIPTION
## Description

Backports #284 to v3.2

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. We only track builds on main and branches tracking old Solidus releases. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2) channel on [Solidus' Slack workspace (https://solidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

## Motivation and Context

We want to get an alert when a build on a supported branch is broken.

## How Has This Been Tested?

Manually on a fork and a private slack app.

## Screenshots (if appropriate):

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202761161-c405a031-1277-407b-b721-0a9bc68e4acc.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the documentation accordingly.
