### PR TITLE
Prevent New Line Before Colon After Payment Name

### DIFF
--- a/templates/app/views/orders/_payment_info.html.erb
+++ b/templates/app/views/orders/_payment_info.html.erb
@@ -22,7 +22,7 @@
         <li><%= source.name %></li>
       </ul>
     <% elsif source.is_a?(Spree::StoreCredit) %>
-      <%= content_tag(:p, payment.payment_method.name) %>:
+      <%= content_tag(:p, "#{payment.payment_method.name}:") %>
       <%= content_tag(:p, payment.display_amount) %>
     <% else %>
       <%= content_tag(:p, payment.payment_method.name) %>


### PR DESCRIPTION
## Description
There appears to be an oversight where adding the colon on the outside of the "p" tag caused a new line break which puts the colon on the line directly below the payment method name - ex:
```
payment method name

:
amount
```

This commit adds the colon with in the p tag so that they will display on the same line. Another way this could be approached is to use span and then style it, but I felt this was the most practical and simple method for correcting this issue.

<!--- Describe your changes in detail -->

## Motivation and Context
Payment Method Display looks bad with the all those line breaks

## How Has This Been Tested?
Visually

## Screenshots (if appropriate):
|Before|After|
|-----|-----|
|![image](https://user-images.githubusercontent.com/68167430/210637787-bf3a54bf-4aa0-4837-8fc5-3df9121e8293.png)|![image](https://user-images.githubusercontent.com/68167430/210637592-a2486f86-9ddc-4cde-a2e2-914db79835fe.png)|



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
