### PR TITLE
Respond with 400 with invalid search params

### DIFF
--- a/templates/app/controllers/products_controller.rb
+++ b/templates/app/controllers/products_controller.rb
@@ -8,6 +8,10 @@ class ProductsController < StoreController
 
   respond_to :html
 
+  rescue_from Spree::Config.searcher_class::InvalidOptions do |error|
+    raise ActionController::BadRequest.new, error.message
+  end
+
   def index
     @searcher = build_searcher(params.merge(include_images: true))
     @products = @searcher.retrieve_products

--- a/templates/spec/requests/products_spec.rb
+++ b/templates/spec/requests/products_spec.rb
@@ -37,4 +37,12 @@ RSpec.describe 'Product', type: :request, with_signed_in_user: true do
       get product_path(product.to_param), headers: { 'HTTP_REFERER' => 'not|a$url' }
     end
   end
+
+  context "when invalid search params are passed" do
+    it "raises ActionController::BadRequest" do
+      expect {
+        get products_path, params: { search: "blurb" }
+      }.to raise_error(ActionController::BadRequest)
+    end
+  end
 end


### PR DESCRIPTION

## Motivation and Context

It is better not to respond with 500, both to avoid polluting error monitoring services, and because it's formally more correct. In fact, malformed user inputs should not raise a 500 error.

This will fail until we merge https://github.com/solidusio/solidus/pull/4844. As soon as it's merged we have the new exception available and we can use it. 

## How Has This Been Tested?

Locally and with specs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
