### PR TITLE
Autocomplete main search with products and taxons

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -172,6 +172,8 @@ with_log['installing routes'] do
 
       resources :products, only: [:index, :show]
 
+      resources :autocomplete_results, only: :index
+
       resources :cart_line_items, only: :create
 
       get '/locale/set', to: 'locale#set'

--- a/templates/app/assets/stylesheets/components/search/_autocomplete_results.scss
+++ b/templates/app/assets/stylesheets/components/search/_autocomplete_results.scss
@@ -1,0 +1,45 @@
+.autocomplete-results {
+  background: $color-white;
+  position: absolute;
+  z-index: 1;
+  left: 0;
+  right: 62px;
+  top: 100%;
+
+  &__title {
+    padding: 10px;
+    font-weight: $buttons-font-weight;
+    font-weight: bold;
+  }
+
+  &__list {
+    border: 1px solid $color-border-medium;
+    border-top: none;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &__item {
+    a {
+      padding: 10px;
+      display: block;
+    }
+  }
+
+  &__item--current, &__item:hover {
+    a {
+      color: $link-color-hover;
+
+      &::after {
+        content: "⏎";
+        margin-left: 10px;
+        opacity: 0.6;
+      }
+    }
+  }
+
+  &__item--empty {
+    padding: 10px;
+  }
+}

--- a/templates/app/assets/stylesheets/screen.scss
+++ b/templates/app/assets/stylesheets/screen.scss
@@ -88,6 +88,7 @@
 @import 'components/products/product_variants';
 @import 'components/products/products_by_taxon';
 @import 'components/products/products_grid';
+@import 'components/search/autocomplete_results';
 @import 'components/search/search_bar';
 @import 'components/search/filter';
 @import 'components/typography/hero_title';

--- a/templates/app/controllers/autocomplete_results_controller.rb
+++ b/templates/app/controllers/autocomplete_results_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class AutocompleteResultsController < StoreController
+  def index
+    respond_to do |format|
+      format.html { redirect_to products_path(keywords: params[:keywords]) }
+      format.turbo_stream { load_results }
+    end
+  end
+
+  private
+
+  def load_results
+    @results ||= begin
+      results = {}
+      results[:products] = autocomplete_products
+      results[:taxons] = autocomplete_taxons
+      results
+    end
+  end
+
+  def autocomplete_products
+    if params[:keywords].present?
+      searcher = build_searcher(params.merge(per_page: 5))
+      searcher.retrieve_products
+    else
+      Spree::Product.none
+    end
+  end
+
+  def autocomplete_taxons
+    if params[:keywords].present?
+      Spree::Taxon
+        .where(Spree::Taxon.arel_table[:name].matches("%#{params[:keywords]}%"))
+        .limit(5)
+    else
+      Spree::Taxon.none
+    end
+  end
+end

--- a/templates/app/javascript/controllers/search_controller.js
+++ b/templates/app/javascript/controllers/search_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "form", "keywords", "results", "result"]
+  static classes = [ "current" ]
+
+  // This is needed to restore the current result index when the
+  // results are updated after a search.
+  resultsTargetConnected() {
+    this.currentResultIndex = 0
+    this.render()
+  }
+
+  fetchResults() {
+    if(this.keywords.length < 2) {
+      this.reset()
+      return
+    }
+
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => this.formTarget.requestSubmit(), 500)
+  }
+
+  nextResult() {
+    if(this.currentResultIndex < this.resultTargets.length - 1) {
+      this.currentResultIndex++
+      this.render()
+    }
+  }
+
+  previousResult() {
+    if(this.currentResultIndex > 0) {
+      this.currentResultIndex--
+      this.render()
+    }
+  }
+
+  openResult() {
+    this.resultTargets[this.currentResultIndex].firstElementChild.click()
+  }
+
+  reset() {
+    this.currentResultIndex = 0
+    if (this.hasResultsTarget) {
+      this.resultsTarget.innerHTML = ""
+    }
+  }
+
+  render() {
+    this.resultTargets.forEach((element, index) => {
+      element.classList.toggle(this.currentClass, index == this.currentResultIndex)
+    })
+  }
+
+  get keywords() {
+    return this.keywordsTarget.value
+  }
+}

--- a/templates/app/views/autocomplete_results/_autocomplete_results.html.erb
+++ b/templates/app/views/autocomplete_results/_autocomplete_results.html.erb
@@ -1,0 +1,36 @@
+<ul class="autocomplete-results__list">
+  <li class="autocomplete-results__title">
+    <%= t('spree.products') %>
+  </li>
+
+  <% if results[:products].any? %>
+    <% results[:products].each do |product| %>
+      <li class="autocomplete-results__item"
+          data-search-target="result">
+        <%= link_to product.name, product_path(product) %>
+      </li>
+    <% end %>
+
+    <li class="autocomplete-results__item"
+        data-search-target="result">
+      <%= link_to "See all results", products_path(keywords: params[:keywords]) %>
+    </li>
+  <% else %>
+    <li class="autocomplete-results__item autocomplete-results__item--empty">No results</li>
+  <% end %>
+
+  <li class="autocomplete-results__title">
+    <%= t('spree.taxons') %>
+  </li>
+
+  <% if results[:taxons].any? %>
+    <% results[:taxons].each do |taxon| %>
+      <li class="autocomplete-results__item"
+          data-search-target="result">
+        <%= link_to taxon.name, nested_taxons_path(taxon) %>
+      </li>
+    <% end %>
+  <% else %>
+    <li class="autocomplete-results__item autocomplete-results__item--empty">No results</li>
+  <% end %>
+</ul>

--- a/templates/app/views/autocomplete_results/index.turbo_stream.erb
+++ b/templates/app/views/autocomplete_results/index.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace 'autocomplete-results' do %>
+  <div id="autocomplete-results" class="autocomplete-results" data-search-target="results">
+    <%= render 'autocomplete_results', results: @results %>
+  </div>
+<% end %>

--- a/templates/app/views/shared/search/_search_bar.html.erb
+++ b/templates/app/views/shared/search/_search_bar.html.erb
@@ -1,31 +1,25 @@
-<%
-  base_class = "search-bar".freeze
+<%= form_tag autocomplete_results_path, method: :get, class: "search-bar",
+    "data-turbo": true,
+    "data-turbo-stream": true,
+    "data-controller": "search",
+    "data-search-current-class": "autocomplete-results__item--current",
+    "data-search-target": "form" do %>
 
-  # Data
-  taxons = taxon && taxon.parent ? taxon.parent.children : Spree::Taxon.roots
-  options = [[t('spree.all_departments'), '']] + taxons.map {|t| [t.name, t.id]}
-  selected = taxon ? taxon.id : params[:taxon]
+  <%= search_field_tag :keywords, params[:keywords], placeholder: "Search", class: "search-bar__input", autocomplete: "off",
+    "data-action": "input->search#fetchResults
+                    keydown.down->search#nextResult
+                    keydown.up->search#previousResult
+                    keydown.enter->search#openResult:prevent:stop
+                    keydown.esc->search#reset:prevent:stop
+                    focusout->search#reset",
+    "data-search-target": "keywords" %>
 
-  # Classes
-  classes = local_assigns.fetch(:classes, [])
-  class_names = classes.push(base_class).join(" ")
-%>
-
-<%= form_tag products_path, class: class_names, method: :get do %>
-  <% cache [I18n.locale, taxons] do %>
-    <%= select_tag(
-      :taxon,
-      options_for_select(options, selected),
-      class: "#{base_class}__select"
-    ) %>
-  <% end %>
-
-  <%= search_field_tag 'keywords', nil, placeholder: 'Search', class: "#{base_class}__input" %>
-
-  <%= button_tag class: "#{base_class}__button", title: 'Search' do %>
-    <svg class="<%= "#{base_class}__icon" %>" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <%= button_tag class: "search-bar__button", title: 'Search' do %>
+    <svg class="search-bar__icon" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M14.5 25C20.299 25 25 20.299 25 14.5C25 8.70101 20.299 4 14.5 4C8.70101 4 4 8.70101 4 14.5C4 20.299 8.70101 25 14.5 25Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       <path d="M21.9243 21.925L27.9994 28.0001" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
   <% end %>
+
+  <div id="autocomplete-results" class="autocomplete-results" data-search-target="results"></div>
 <% end %>

--- a/templates/spec/support/solidus_starter_frontend/shared_contexts/custom_products.rb
+++ b/templates/spec/support/solidus_starter_frontend/shared_contexts/custom_products.rb
@@ -3,17 +3,18 @@
 RSpec.shared_context "custom products" do
   before(:each) do
     create(:store)
-    taxonomy = FactoryBot.create(:taxonomy, name: 'Categories')
-    root = taxonomy.root
-    clothing_taxon = FactoryBot.create(:taxon, name: 'Clothing', parent_id: root.id)
-    bags_taxon = FactoryBot.create(:taxon, name: 'Bags', parent_id: root.id)
-    mugs_taxon = FactoryBot.create(:taxon, name: 'Mugs', parent_id: root.id)
 
-    taxonomy = FactoryBot.create(:taxonomy, name: 'Brands')
-    root = taxonomy.root
-    apache_taxon = FactoryBot.create(:taxon, name: 'Apache', parent_id: root.id)
-    rails_taxon = FactoryBot.create(:taxon, name: 'Ruby on Rails', parent_id: root.id)
-    ruby_taxon = FactoryBot.create(:taxon, name: 'Ruby', parent_id: root.id)
+    categories = FactoryBot.create(:taxonomy, name: 'Categories')
+    categories_root = categories.root
+    clothing_taxon = FactoryBot.create(:taxon, name: 'Clothing', parent_id: categories_root.id, taxonomy: categories)
+    bags_taxon = FactoryBot.create(:taxon, name: 'Bags', parent_id: categories_root.id, taxonomy: categories)
+    mugs_taxon = FactoryBot.create(:taxon, name: 'Mugs', parent_id: categories_root.id, taxonomy: categories)
+
+    brands = FactoryBot.create(:taxonomy, name: 'Brands')
+    brands_root = brands.root
+    apache_taxon = FactoryBot.create(:taxon, name: 'Apache', parent_id: brands_root.id, taxonomy: brands)
+    rails_taxon = FactoryBot.create(:taxon, name: 'Ruby on Rails', parent_id: brands_root.id, taxonomy: brands)
+    ruby_taxon = FactoryBot.create(:taxon, name: 'Ruby', parent_id: brands_root.id, taxonomy: brands)
 
     FactoryBot.create(:custom_product, name: 'Ruby on Rails Ringer T-Shirt', price: '19.99', taxons: [rails_taxon, clothing_taxon])
     FactoryBot.create(:custom_product, name: 'Ruby on Rails Mug', price: '15.99', taxons: [rails_taxon, mugs_taxon])

--- a/templates/spec/system/caching/taxons_spec.rb
+++ b/templates/spec/system/caching/taxons_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe 'taxons', type: :system, caching: true do
     visit products_path
     # Cache rewrites:
     # - 2 x categories component
-    # - 1 x taxons list in search form
     # - 1 x categories in navigation
-    expect(cache_writes.count).to eq(4)
+    expect(cache_writes.count).to eq(3)
   end
 
   it "busts the cache when max_level_in_taxons_menu conf changes" do

--- a/templates/spec/system/products_spec.rb
+++ b/templates/spec/system/products_spec.rb
@@ -138,13 +138,6 @@ RSpec.describe 'Visiting Products', type: :system, inaccessible: true do
     end
   end
 
-  it 'should be able to search for a product' do
-    fill_in 'keywords', with: 'shirt'
-    click_button 'Search'
-
-    expect(page.all('ul.products-grid li').size).to eq(1)
-  end
-
   context 'a product with variants' do
     let(:product) do
       Spree::Product.find_by(name: 'Ruby on Rails Baseball Jersey')

--- a/templates/spec/system/search_spec.rb
+++ b/templates/spec/system/search_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'solidus_starter_frontend_helper'
+
+RSpec.describe 'searching products', type: :system do
+  include_context "custom products"
+
+  before(:each) do
+    visit root_path
+  end
+
+  it 'falls back to normal search for plain HTML requests' do
+    fill_in 'keywords', with: 'shirt'
+    click_button 'Search'
+
+    expect(page.all('ul.products-grid li').size).to eq(1)
+  end
+
+  context 'with JS enabled', :js do
+    it 'shows autocomplete suggestions' do
+      fill_in 'keywords', with: 'ruby'
+      expect(page.all('[data-search-target="result"]').size).to eq(8)
+    end
+
+    it 'automatically selects the first suggestion' do
+      fill_in 'keywords', with: 'ruby'
+      expect(page.all('[data-search-target="result"]')[0][:class]).to include('autocomplete-results__item--current')
+    end
+
+    it 'scrolls up and down through suggestions using up/down arrow keys' do
+      fill_in 'keywords', with: 'ruby'
+      # wait for the autocomplete to show up
+      expect(page.all('[data-search-target="result"]')[0][:class]).to include('autocomplete-results__item--current')
+
+      find('input[name=keywords]').native.send_keys(:down)
+      expect(page.all('[data-search-target="result"]')[1][:class]).to include('autocomplete-results__item--current')
+
+      find('input[name=keywords]').native.send_keys(:up)
+      expect(page.all('[data-search-target="result"]')[0][:class]).to include('autocomplete-results__item--current')
+    end
+
+    it 'clicks on a suggestion pressing enter' do
+      fill_in 'keywords', with: 'ruby'
+      # wait for the autocomplete to show up
+      expect(page.all('[data-search-target="result"]')[0][:class]).to include('autocomplete-results__item--current')
+      find('input[name=keywords]').native.send_keys(:enter)
+
+      expect(page).to have_current_path('/products/ruby-on-rails-ringer-t-shirt')
+    end
+
+    it 'closes autocomplete suggestions pressing esc key' do
+      fill_in 'keywords', with: 'ruby'
+      # wait for the autocomplete to show up
+      expect(page).to have_selector('[data-search-target="result"]', visible: true)
+      find('input[name=keywords]').native.send_keys(:escape)
+
+      expect(page).not_to have_selector('[data-search-target="result"]', visible: true)
+    end
+
+    it 'closes autocomplete suggestions clicking outside the search input' do
+      fill_in 'keywords', with: 'ruby'
+      # wait for the autocomplete to show up
+      expect(page).to have_selector('[data-search-target="result"]', visible: true)
+      find('input[name=keywords]').native.send_keys(:escape)
+
+      find('.top-bar').click
+      expect(page).not_to have_selector('[data-search-target="result"]', visible: true)
+    end
+  end
+end


### PR DESCRIPTION
Adds some very basic autocomplete functionalities to our main search input. It returns results for what has been typed so far for products and taxons, up to 5 for each type.

For products, it also allows users to see all results for the given keyword, falling back to the standard search. 

Once the suggestions box appears, some very basic UX allows to navigate results:

- Key down: go to the next result.
- Key up: go to the previous results.
- Enter: open the currently selected result.
- Esc: close the suggestions box.
- Click anywhere else on the page: close the suggestions box.

![Screenshot 2023-02-02 at 14 52 31](https://user-images.githubusercontent.com/167946/216343971-3391f825-2a86-453f-86c2-f7e00a5522ac.gif)

Thanks @elia for guidance and help during its development.

## Description

This feature uses stimulus to submit the form on every key pressed in the search input (if > 2 chars) and add some UX to navigate the results.

Turbo stream will take care of updating the results section with the suggestions retrieved from the new specific controller action introduced.

## Motivation and Context

We want to provide a basic implementation for stores that want to add autocomplete capabilities to their store. This solution is basic but highly customizable based on each store's specific needs.

## How Has This Been Tested?

Tested manually and via specs (see PR changes). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
