### PR TITLE
Remove --skip-javascript from install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All of this while keeping and improving on the functionality of the current
 Just run:
 
 ```bash
-rails new store --skip-javascript
+rails new store
 cd store
 bundle add solidus
 bin/rails generate solidus:install --frontend=solidus_starter_frontend


### PR DESCRIPTION
## Description

Assuming people will use this project with at least Rails 7 at this point, we can avoid skipping javascript installation.

Webpacker is no more an issue!

This PR is a friend of https://github.com/solidusio/edgeguides/pull/90.

## Motivation and Context

We started adding features that rely on the JS stack provided with Rails 7, like Stimulus and Turbo. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
