### PR TITLE
Remove solidus branch default value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ commands:
     parameters:
       solidus_branch:
         type: string
-        default: master
       rails_version:
         type: string
       ruby_version:


### PR DESCRIPTION
Small follow-up for #302 (sorry I didn't catch it there 🙏 ).

## Description

In the test command, we used to have this default, but it's useless because we are always passing it when invoking the command in the run-specs job (see line 86).


## Motivation and Context

Having the default version in a single place will allow us to change it only once when we create a new version branch and we need to make its test suite point to a specific solidus version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
