### PR TITLE
[v3.3] Remove Slack notifications for CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3.0
-  slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -73,13 +72,6 @@ commands:
           name: 'Solidus <<parameters.branch>>: Clean up'
           when: always
 
-  notify:
-    steps:
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-          branch_pattern: main, v[0-9]+\.[0-9]+
-
 jobs:
   run-specs:
     executor:
@@ -91,7 +83,6 @@ jobs:
           branch: <<parameters.solidus_branch>>
           rails_version: <<parameters.rails_version>>
       - solidusio_extensions/store-test-results
-      - notify
     parameters:
       solidus_branch:
         type: string
@@ -110,31 +101,25 @@ workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs:
-          context: slack-secrets
           name: run-specs-with-solidus-3-2-rails-7-ruby-3-1-postgres
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-solidus-latest
           solidus_branch: 'master'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-rails-6
           rails_version: '~> 6.1'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-ruby-3-0
           ruby_version: '3.0'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-ruby-2
           ruby_version: '2.7'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-mysql
           database: 'mysql'
 
@@ -148,30 +133,24 @@ workflows:
                 - master
     jobs:
       - run-specs:
-          context: slack-secrets
           name: run-specs-with-solidus-3-2-rails-7-ruby-3-1-postgres
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-solidus-latest
           solidus_branch: 'master'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-rails-6
           rails_version: '~> 6.1'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-ruby-3-0
           ruby_version: '3.0'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-ruby-2
           ruby_version: '2.7'
 
       - run-specs:
-          context: slack-secrets
           name: run-specs-but-with-mysql
           database: 'mysql'


### PR DESCRIPTION
## Summary

We were storing the Slack secrets on a [CircleCI context](https://circleci.com/docs/contexts/). Although we were also [passing them to forks](https://circleci.com/docs/oss/#pass-secrets-to-builds-from-forked-pull-requests), it resulted on unauthorized builds for external contributions.

We could work around the issue in two ways:

- Having the secrets outside of any context, but that would compromise the security of the associated Slack channel for:
  - Send messages as @<!---->CircleCI notifications
  - Send messages to channels @<!---->CircleCI notifications isn't a member of
  - Upload, edit, and delete files as CircleCI notifications
- Using CircleCI [logic statements](https://circleci.com/docs/configuration-reference/#logic-statements) to conditionally run jobs when `CIRCLECI_USERNAME` or `CIRCLE_PR_USERNAME` [env vars](https://circleci.com/docs/variables/) are in a list of allowed users. However, that would be something difficult to maintain, and there's no other way to check the user's role.

Given that we don't find those trade-offs to be acceptable, we remove the integration for now.

Closes #4902

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
