### PR TITLE
Abort installation when Rails < 7

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -6,12 +6,12 @@ with_log = ->(message, &block) {
 }
 
 with_log['checking versions'] do
-  if Rails.gem_version < Gem::Version.new('6.1')
-    say_status :unsupported, shell.set_color(
-      "You are installing solidus_starter_frontend on an outdated Rails version.\n" \
-      "Please keep in mind that some features might not work with it.", :bold
+  if Rails.gem_version < Gem::Version.new('7.0')
+    say_status :error, shell.set_color(
+      "You are trying to install solidus_starter_frontend on an outdated Rails version.\n" \
+      "This installation attempt has been aborted, please retry using at least Rails 7.", :bold
     ), :red
-    exit 1 if auto_accept || no?("Do you wish to proceed?")
+    exit 1
   end
 
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')


### PR DESCRIPTION
## Description

We now have features that are only compatible with the last version of Rails and we are assuming the project will be only installed on the latest.

This change let the installer exit if a previous version is detected, printing a message that asks to retry with latest Rails.

## Motivation and Context

We don't want Solidus Starter Frontend to be installed with old versions of Rails, otherwise new features won't work.

## How Has This Been Tested?

I changed the sandbox script to use an old version of Rails:

```
rails _6.1.7.2_ new sandbox \
  --skip-git \
  --database=${DB:-sqlite3} \
  --skip-rc
```

The result is Rails and Solidus installed, but the Solidus Starter Frontend template script aborted with the corresponding message. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
