### PR TITLE
Fix checkout step on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.3.0
+  browser-tools: circleci/browser-tools@1.4.1
   slack: circleci/slack@4.9.3
 
   # Always take the latest version of the orb, this allows us to
@@ -13,9 +13,9 @@ orbs:
 commands:
   setup:
     steps:
+      - checkout
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      - checkout
       - run:
           name: Install libvips
           command: |


### PR DESCRIPTION
## Description

We're bumping the browser-tools-orb version to fetch the fix implemented at https://github.com/CircleCI-Public/browser-tools-orb/pull/63.

The issue was due to chromedriver adding a file within the project directory, making it impossible to checkout our code there in a following step.

To be on the safe side for future possible regressions, we're moving our checkout step to the top of the stack to ensure it finds a pristine directory.

Closes #315

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
