### PR TITLE
Fix clicking on autocomplete results

### DIFF
--- a/templates/app/javascript/controllers/search_controller.js
+++ b/templates/app/javascript/controllers/search_controller.js
@@ -39,6 +39,12 @@ export default class extends Controller {
     this.resultTargets[this.currentResultIndex].firstElementChild.click()
   }
 
+  focusOut(event) {
+    if (!this.formTarget.contains(event.target)) {
+      this.reset()
+    }
+  }
+
   reset() {
     this.currentResultIndex = 0
     if (this.hasResultsTarget) {

--- a/templates/app/views/shared/search/_search_bar.html.erb
+++ b/templates/app/views/shared/search/_search_bar.html.erb
@@ -11,7 +11,8 @@
                     keydown.up->search#previousResult
                     keydown.enter->search#openResult:prevent:stop
                     keydown.esc->search#reset:prevent:stop
-                    focusout->search#reset",
+                    click@window->search#focusOut
+                    ",
     "data-search-target": "keywords" %>
 
   <%= button_tag class: "search-bar__button", title: 'Search' do %>

--- a/templates/spec/system/search_spec.rb
+++ b/templates/spec/system/search_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe 'searching products', type: :system do
       expect(page.all('[data-search-target="result"]')[0][:class]).to include('autocomplete-results__item--current')
     end
 
+    it 'allows mouse click on results' do
+      fill_in 'keywords', with: 'ruby'
+      # wait for the autocomplete to show up
+      expect(page.all('[data-search-target="result"]')[0][:class]).to include('autocomplete-results__item--current')
+      find_all('[data-search-target="result"]')[0].click
+
+      expect(page).to have_current_path('/products/ruby-on-rails-ringer-t-shirt')
+    end
+
     it 'clicks on a suggestion pressing enter' do
       fill_in 'keywords', with: 'ruby'
       # wait for the autocomplete to show up


### PR DESCRIPTION
## Description

Fixes #313

Follow-up for #300 

## Motivation and Context

By clicking on one of the results item, the `focusout` event is triggered and it acts before the `click` event is triggered, removing the list.

To solve this, we listen to all click events and do nothing if the click is internal to the autcomplete, otherwise it resets it.

## How Has This Been Tested?

By automated tests and in the sandbox locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
