### PR TITLE
Block clicks on disabled form elements

### DIFF
--- a/templates/app/assets/stylesheets/components/checkout/steps/_payment_step.scss
+++ b/templates/app/assets/stylesheets/components/checkout/steps/_payment_step.scss
@@ -21,6 +21,7 @@
 
     &:disabled {
       opacity: 0.5;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
## Summary

Payment iframes like Braintree or Stripe are still interactable even when the fieldset is disabled. Adding this will fix that.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
