### PR TITLE
Track spec coverage with codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ commands:
         type: string
       database:
         type: string
+      coverage:
+        type: boolean
 
     steps:
       - run:
@@ -46,7 +48,9 @@ commands:
           when: always
       - run:
           name: 'Solidus <<parameters.solidus_branch>>:  Install sandbox with generated starter frontend'
-          command: bin/sandbox --seed=false --sample=false
+          command: |
+            <<#parameters.coverage>>export COVERAGE=true<</parameters.coverage>>
+            bin/sandbox --seed=false --sample=false
           environment:
             RAILS_ENV: development # if run in test mode will attempt to eager-load and break the sandbox
             RAILS_VERSION: <<parameters.rails_version>>
@@ -57,6 +61,7 @@ commands:
           command: |
             cd sandbox
             bundle add rspec_junit_formatter --group test
+            <<#parameters.coverage>>export COVERAGE=true<</parameters.coverage>>
             bundle exec rspec --format progress --format RspecJunitFormatter --out ../test-results/results.xml
           environment:
             RAILS_VERSION: <<parameters.rails_version>>
@@ -79,6 +84,8 @@ jobs:
           rails_version: <<parameters.rails_version>>
           ruby_version: <<parameters.ruby_version>>
           database: <<parameters.database>>
+          coverage: <<parameters.coverage>>
+
       - solidusio_extensions/store-test-results
     parameters:
       solidus_branch:
@@ -91,6 +98,9 @@ jobs:
         type: string
       database:
         type: string
+      coverage:
+        type: boolean
+        default: false
 
 workflows:
   "Run specs on development Solidus version":
@@ -99,6 +109,7 @@ workflows:
           name: run-specs-with-postgres-ruby-3-2
           database: 'postgres'
           ruby_version: '3.2'
+          coverage: true
 
       - run-specs:
           name: run-specs-with-postgres-ruby-3-1
@@ -114,8 +125,10 @@ workflows:
           name: run-specs-with-mysql-ruby-3-2
           database: 'mysql'
           ruby_version: '3.2'
+          coverage: true
 
       - run-specs:
           name: run-specs-with-sqlite-ruby-3-2
           database: 'sqlite'
           ruby_version: '3.2'
+          coverage: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,27 +105,25 @@ jobs:
 workflows:
   "Run specs on development Solidus version":
     jobs:
-      - run-specs:
-          name: run-specs-with-postgres-ruby-3-2
-          database: 'postgres'
-          ruby_version: '3.2'
-          coverage: true
-
-      - run-specs:
-          name: run-specs-with-postgres-ruby-3-1
-          database: 'postgres'
-          ruby_version: '3.1'
-
-      - run-specs:
-          name: run-specs-with-postgres-ruby-3-0
-          database: 'postgres'
-          ruby_version: '2.7'
-
-      - run-specs:
-          name: run-specs-with-mysql-ruby-3-2
-          database: 'mysql'
-          ruby_version: '3.2'
-          coverage: true
+      # - run-specs:
+      #     name: run-specs-with-postgres-ruby-3-2
+      #     database: 'postgres'
+      #     ruby_version: '3.2'
+      #
+      # - run-specs:
+      #     name: run-specs-with-postgres-ruby-3-1
+      #     database: 'postgres'
+      #     ruby_version: '3.1'
+      #
+      # - run-specs:
+      #     name: run-specs-with-postgres-ruby-3-0
+      #     database: 'postgres'
+      #     ruby_version: '2.7'
+      #
+      # - run-specs:
+      #     name: run-specs-with-mysql-ruby-3-2
+      #     database: 'mysql'
+      #     ruby_version: '3.2'
 
       - run-specs:
           name: run-specs-with-sqlite-ruby-3-2

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,7 @@ gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0'
 group :development do
   gem 'guard'
   gem 'guard-shell'
+
+  gem 'codecov'
+  gem 'simplecov', '~> 0.22'
 end

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -39,6 +39,11 @@ fi
 
 cd ./sandbox
 
+# Add support for tracking coverage
+unbundled bundle add simplecov -v 0.22 --require=false --skip-install
+unbundled bundle add codecov --require=false
+echo "require_relative '../../coverage.rb' if ENV['COVERAGE']" >> config/boot.rb
+
 test -n "${host}" && replace_in_database_yml "host" "${host}"
 test -n "${username}" && replace_in_database_yml "username" "${username}"
 test -n "${password}" && replace_in_database_yml "password" "${password}"

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -15,7 +15,7 @@ replace_in_database_yml() {
 
 # Stay away from the bundler env of the containing extension.
 function unbundled {
-  ruby -rbundler -e'b = proc {system *ARGV}; Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&b) : Bundler.with_clean_env(&b)' -- "$@"
+  ruby -rbundler -e'Bundler.with_unbundled_env { system *ARGV }' -- "$@"
 }
 
 # "sqlite" is set by the ORB extension instead of "sqlite3",

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto

--- a/coverage.rb
+++ b/coverage.rb
@@ -12,21 +12,12 @@ else
   warn "Provide a CODECOV_TOKEN environment variable to enable Codecov uploads"
 end
 
+COVERAGE_ROOT = ENV['COVERAGE_ROOT'] || File.expand_path "#{__dir__}/.."
+
 SimpleCov.start do
-  root ENV['COVERAGE_ROOT'] || File.expand_path('..', SimpleCov.root) # up one level
+  root COVERAGE_ROOT
   enable_for_subprocesses true
   enable_coverage_for_eval
   add_filter %r{sandbox/(db|config|spec|tmp)/}
   track_files "#{SimpleCov.root}/{template.rb,sandbox/**/*.{erb,rb}}"
-
-  at_fork do |pid|
-    SimpleCov.start do
-      command_name "#{command_name} (subprocess: #{pid})"
-
-      # Be quiet, the parent process will be in charge of output and checking coverage totals.
-      print_error_status = false
-      formatter SimpleCov::Formatter::SimpleFormatter
-      minimum_coverage 0
-    end
-  end
 end

--- a/coverage.rb
+++ b/coverage.rb
@@ -1,0 +1,32 @@
+require 'coverage'
+require 'simplecov'
+
+if ENV['CODECOV_TOKEN']
+  require 'codecov'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::Codecov,
+    SimpleCov.formatter,
+  ])
+else
+  warn "Provide a CODECOV_TOKEN environment variable to enable Codecov uploads"
+end
+
+SimpleCov.start do
+  root ENV['COVERAGE_ROOT'] || File.expand_path('..', SimpleCov.root) # up one level
+  enable_for_subprocesses true
+  enable_coverage_for_eval
+  add_filter %r{sandbox/(db|config|spec|tmp)/}
+  track_files "#{SimpleCov.root}/{template.rb,sandbox/**/*.{erb,rb}}"
+
+  at_fork do |pid|
+    SimpleCov.start do
+      command_name "#{command_name} (subprocess: #{pid})"
+
+      # Be quiet, the parent process will be in charge of output and checking coverage totals.
+      print_error_status = false
+      formatter SimpleCov::Formatter::SimpleFormatter
+      minimum_coverage 0
+    end
+  end
+end

--- a/templates/spec/support/solidus_starter_frontend/capybara.rb
+++ b/templates/spec/support/solidus_starter_frontend/capybara.rb
@@ -8,6 +8,15 @@ require 'spree/testing_support/capybara_ext'
 
 Capybara.default_max_wait_time = 10
 
+# Fix a selenium deprecation warning.
+# Ref: https://github.com/rails/rails/pull/47117
+require 'action_dispatch/system_testing/driver'
+ActionDispatch::SystemTesting::Driver.class_eval do
+  def browser_options
+    @options.merge(options: @browser.options).compact
+  end
+end
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by((ENV['CAPYBARA_DRIVER'] || :rack_test).to_sym)


### PR DESCRIPTION
## Summary

- Coverage is reported for the `sandbox/` dir (I wasn't able to trick SimpleCov into believing those paths were in `templates/`)
- Enabled only for 3.2 which is able able track ERB files

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
