### PR TITLE
Restore commented out CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,25 +105,25 @@ jobs:
 workflows:
   "Run specs on development Solidus version":
     jobs:
-      # - run-specs:
-      #     name: run-specs-with-postgres-ruby-3-2
-      #     database: 'postgres'
-      #     ruby_version: '3.2'
-      #
-      # - run-specs:
-      #     name: run-specs-with-postgres-ruby-3-1
-      #     database: 'postgres'
-      #     ruby_version: '3.1'
-      #
-      # - run-specs:
-      #     name: run-specs-with-postgres-ruby-3-0
-      #     database: 'postgres'
-      #     ruby_version: '2.7'
-      #
-      # - run-specs:
-      #     name: run-specs-with-mysql-ruby-3-2
-      #     database: 'mysql'
-      #     ruby_version: '3.2'
+      - run-specs:
+          name: run-specs-with-postgres-ruby-3-2
+          database: 'postgres'
+          ruby_version: '3.2'
+
+      - run-specs:
+          name: run-specs-with-postgres-ruby-3-1
+          database: 'postgres'
+          ruby_version: '3.1'
+
+      - run-specs:
+          name: run-specs-with-postgres-ruby-3-0
+          database: 'postgres'
+          ruby_version: '2.7'
+
+      - run-specs:
+          name: run-specs-with-mysql-ruby-3-2
+          database: 'mysql'
+          ruby_version: '3.2'
 
       - run-specs:
           name: run-specs-with-sqlite-ruby-3-2


### PR DESCRIPTION
They were commented out for quickly trying out an alternative configuration but never removed before the merge of #329.

🤦‍♂️ 

## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
