### PR TITLE
Fix specs to be compliant with taxon/taxonomy factories improvements on solidus

### DIFF
--- a/templates/spec/components/breadcrumbs_component_spec.rb
+++ b/templates/spec/components/breadcrumbs_component_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe BreadcrumbsComponent, type: :component do
     end
 
     context 'when the taxon is present' do
-      let(:parent) { nil }
-      let(:grandparent) { nil }
-      let(:taxon) { create(:taxon, name: 'some taxon', parent: parent) }
+      let(:taxon) { create(:taxon, name: 'some taxon') }
 
       context 'when the current page is the root page' do
         let(:request_url) { '/' }
@@ -43,25 +41,12 @@ RSpec.describe BreadcrumbsComponent, type: :component do
       context 'when the current page is not the root page' do
         let(:request_url) { '/products' }
 
-        context 'when the taxon has no ancestors' do
-          let(:parent) { nil }
-
-          it 'renders a breadcrumb for the taxon' do
-            expect(breadcrumb_items.size).to eq(3)
-            expect(breadcrumb_items.last).to eq(taxon.name)
-          end
-        end
-
-        context 'when the taxon has ancestors' do
-          let(:grandparent) { create(:taxon, name: 'some grandparent', parent: nil) }
-          let(:parent) { create(:taxon, name: 'some parent', parent: grandparent) }
-
-          it 'renders a breadcrumb for the taxon and its ancestors' do
-            expect(breadcrumb_items.size).to eq(5)
-            expect(breadcrumb_items[-3]).to eq(grandparent.name)
-            expect(breadcrumb_items[-2]).to eq(parent.name)
-            expect(breadcrumb_items[-1]).to eq(taxon.name)
-          end
+        it 'renders a breadcrumb for the taxon and its ancestors' do
+          expect(breadcrumb_items.size).to eq(4)
+          expect(breadcrumb_items[-4]).to eq('Home')
+          expect(breadcrumb_items[-3]).to eq('Products')
+          expect(breadcrumb_items[-2]).to eq(taxon.parent.name) # default taxonomy taxon root
+          expect(breadcrumb_items[-1]).to eq(taxon.name)
         end
       end
     end

--- a/templates/spec/helpers/spree/base_helper_spec.rb
+++ b/templates/spec/helpers/spree/base_helper_spec.rb
@@ -5,7 +5,9 @@ require 'solidus_starter_frontend_spec_helper'
 RSpec.describe Spree::BaseHelper, type: :helper do
   # Regression test for https://github.com/spree/spree/issues/2759
   it "nested_taxons_path works with a Taxon object" do
-    taxon = create(:taxon, name: "iphone")
-    expect(nested_taxons_path(taxon)).to eq("/t/iphone")
+    taxonomy = create(:taxonomy, name: 'smartphone')
+    taxon = create(:taxon, taxonomy: taxonomy, name: "iphone")
+
+    expect(nested_taxons_path(taxon)).to eq("/t/smartphone/iphone")
   end
 end

--- a/templates/spec/helpers/taxons_helper_spec.rb
+++ b/templates/spec/helpers/taxons_helper_spec.rb
@@ -4,11 +4,11 @@ require 'solidus_starter_frontend_spec_helper'
 
 RSpec.describe TaxonsHelper, type: :helper do
   describe '#taxon_seo_url' do
-    let(:taxon_permalink) { 'ruby-on-rails' }
-    let(:taxon) { create(:taxon, permalink: taxon_permalink) }
+    let(:taxonomy) { create(:taxonomy, name: 'Categories') }
+    let(:taxon) { create(:taxon, name: 'Clothing', taxonomy: taxonomy) }
 
     it 'is the nested taxons path for the taxon' do
-      expect(taxon_seo_url(taxon)).to eq("/t/#{taxon_permalink}")
+      expect(taxon_seo_url(taxon)).to eq("/t/categories/clothing")
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR addresses an issue that caused some specs on `solidus_starter_frontend` to fail.
The issue was identified to be related to recent changes made in the main Solidus repository (See the attached issue for more details)

We have updated the taxon specs to ensure compatibility with the latest changes.

Fixes #331

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
