### PR TITLE
Stop using the deprecated codecov gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,11 @@ orbs:
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
 
-commands:
-  setup:
+jobs:
+  run-specs:
+    executor:
+        name: solidusio_extensions/<<parameters.database>>
+        ruby_version: <<parameters.ruby_version>>
     steps:
       - checkout
       - browser-tools/install-chrome
@@ -21,24 +24,6 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -yq libvips-dev
-
-  test-branch:
-    description:
-      Runs tests for a specific Solidus branch.
-
-    parameters:
-      solidus_branch:
-        type: string
-      rails_version:
-        type: string
-      ruby_version:
-        type: string
-      database:
-        type: string
-      coverage:
-        type: boolean
-
-    steps:
       - run:
           name: 'Solidus <<parameters.solidus_branch>>:  Install gems'
           command: |
@@ -82,22 +67,8 @@ commands:
           command: rm -rf sandbox
           name: 'Solidus <<parameters.solidus_branch>>: Clean up'
           when: always
-
-jobs:
-  run-specs:
-    executor:
-        name: solidusio_extensions/<<parameters.database>>
-        ruby_version: <<parameters.ruby_version>>
-    steps:
-      - setup
-      - test-branch:
-          solidus_branch: <<parameters.solidus_branch>>
-          rails_version: <<parameters.rails_version>>
-          ruby_version: <<parameters.ruby_version>>
-          database: <<parameters.database>>
-          coverage: <<parameters.coverage>>
-
       - solidusio_extensions/store-test-results
+
     parameters:
       solidus_branch:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.4.1
+  codecov: codecov/codecov@3.2.4
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -67,6 +68,10 @@ commands:
             RAILS_VERSION: <<parameters.rails_version>>
             SOLIDUS_BRANCH: <<parameters.solidus_branch>>
           when: always
+      - when:
+          condition: <<parameters.coverage>>
+          steps: ["codecov/upload"]
+          path: test-results
       - run:
           command: rm -rf sandbox
           name: 'Solidus <<parameters.solidus_branch>>: Clean up'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,12 @@ commands:
           condition: <<parameters.coverage>>
           steps: ["codecov/upload"]
           path: test-results
+      - store_artifacts:
+          path: /home/circleci/project/sandbox/tmp/capybara/
+          destination: capybara
+      - store_artifacts:
+          path: /home/circleci/project/coverage/
+          destination: coverage
       - run:
           command: rm -rf sandbox
           name: 'Solidus <<parameters.solidus_branch>>: Clean up'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 # Solidus Starter Frontend
 [![CircleCI](https://circleci.com/gh/solidusio/solidus_starter_frontend.svg?style=shield)](https://circleci.com/gh/solidusio/solidus_starter_frontend)
+[![codecov](https://codecov.io/gh/solidusio/solidus_starter_frontend/branch/master/graph/badge.svg?token=54gge25dNh)](https://codecov.io/gh/solidusio/solidus_starter_frontend)
 
 `solidus_starter_frontend` is a new starter storefront for [Solidus][solidus].
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -39,10 +39,12 @@ fi
 
 cd ./sandbox
 
-# Add support for tracking coverage
-unbundled bundle add simplecov -v 0.22 --require=false --skip-install
-unbundled bundle add codecov --require=false
+# Coverage
 echo "require_relative '../../coverage.rb' if ENV['COVERAGE']" >> config/boot.rb
+echo "gem 'rspec_junit_formatter', require: false" >> Gemfile
+echo "gem 'simplecov', '~> 0.22', require: false" >> Gemfile
+echo "gem 'simplecov-cobertura', require: false" >> Gemfile
+unbundled bundle install
 
 test -n "${host}" && replace_in_database_yml "host" "${host}"
 test -n "${username}" && replace_in_database_yml "username" "${username}"

--- a/coverage.rb
+++ b/coverage.rb
@@ -1,23 +1,42 @@
+# frozen_string_literal: true
+
 require 'coverage'
 require 'simplecov'
 
+SimpleCov.root File.expand_path(__dir__)
+
 if ENV['CODECOV_TOKEN']
-  require 'codecov'
+  require 'simplecov-cobertura'
 
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::Codecov,
+    SimpleCov::Formatter::CoberturaFormatter,
     SimpleCov.formatter,
   ])
 else
   warn "Provide a CODECOV_TOKEN environment variable to enable Codecov uploads"
 end
 
-COVERAGE_ROOT = ENV['COVERAGE_ROOT'] || File.expand_path "#{__dir__}/.."
+def (SimpleCov::ResultAdapter).call(result)
+  result = result.transform_keys do |path|
+    template_path = path.sub(
+      "#{SimpleCov.root}/sandbox/",
+      "#{SimpleCov.root}/templates/"
+    )
+    File.exist?(template_path) ? template_path : path
+  end
+  result.each do |path, coverage|
+    next unless path.end_with?('.erb')
 
+    # Remove the extra trailing lines added by ERB
+    coverage[:lines] = coverage[:lines][...File.read(path).lines.size]
+  end
+  result
+end
+
+warn "Tracking coverage on process #{$$}..."
 SimpleCov.start do
-  root COVERAGE_ROOT
-  enable_for_subprocesses true
+  root __dir__
   enable_coverage_for_eval
   add_filter %r{sandbox/(db|config|spec|tmp)/}
-  track_files "#{SimpleCov.root}/{template.rb,sandbox/**/*.{erb,rb}}"
+  track_files "#{SimpleCov.root}/{sandbox,lib,app}/**/*.{rb,erb}}"
 end


### PR DESCRIPTION
## Summary

That gem is deprecated and a migration to the CI integration + copertura is strongly advised.

Ref: https://github.com/solidusio/solidus_stripe/pull/227

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
