### PR TITLE
Fix factories loading

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -115,7 +115,7 @@ with_log['installing files'] do
   application <<~RUBY
     if defined?(FactoryBotRails)
       initializer after: "factory_bot.set_factory_paths" do
-        require 'spree/testing_support'
+        require 'spree/testing_support/factory_bot'
         FactoryBot.definition_file_paths = [
           *Spree::TestingSupport::FactoryBot.definition_file_paths,
           Rails.root.join('spec/fixtures/factories'),


### PR DESCRIPTION
## Summary

With Solidus v4.0 we don't have the factories defined in `spree/testing_support` anymore. Better to fetch them from the proper file that includes all the definitions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
