### PR TITLE
Add explicit responders dependency

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -64,6 +64,7 @@ with_log['installing gems'] do
     generate 'solidus:auth:install'
   end
 
+  gem 'responders'
   gem 'canonical-rails'
   gem 'solidus_support'
   gem 'truncate_html'

--- a/templates/app/controllers/cart_line_items_controller.rb
+++ b/templates/app/controllers/cart_line_items_controller.rb
@@ -26,7 +26,7 @@ class CartLineItemsController < StoreController
       end
     end
 
-    respond_with(@order) do |format|
+    respond_to do |format|
       format.html do
         if @order.errors.any?
           flash[:error] = @order.errors.full_messages.join(", ")

--- a/templates/app/controllers/carts_controller.rb
+++ b/templates/app/controllers/carts_controller.rb
@@ -25,7 +25,7 @@ class CartsController < StoreController
     if @order.contents.update_cart(order_params)
       @order.next if params.key?(:checkout) && @order.cart?
 
-      respond_with(@order) do |format|
+      respond_to do |format|
         format.html do
           if params.key?(:checkout)
             redirect_to checkout_state_path(@order.checkout_steps.first)

--- a/templates/app/controllers/coupon_codes_controller.rb
+++ b/templates/app/controllers/coupon_codes_controller.rb
@@ -11,7 +11,7 @@ class CouponCodesController < StoreController
       @order.coupon_code = params[:coupon_code]
       handler = Spree::PromotionHandler::Coupon.new(@order).apply
 
-      respond_with(@order) do |format|
+      respond_to do |format|
         format.html do
           if handler.successful?
             flash[:success] = handler.success


### PR DESCRIPTION
## Summary

With solidusio/solidus#5158, we removed `respond_to :html` from `Spree::BaseController`. That's because `responders` is no more a core dependency and `Spree::BaseController` is defined there.

Still, the starter frontend is using it and we can't remove all occurrences of its usage now, mainly because part of them are used in the authentication system (it's a devise dependency) and it takes some time to understand what we can remove/change without security issues.

We take advantage of this change to also remove some useless usage of `respond_with`.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
