### PR TITLE
Handle checkout process for orders fully covered by store credits

### DIFF
--- a/templates/app/controllers/checkouts_controller.rb
+++ b/templates/app/controllers/checkouts_controller.rb
@@ -81,7 +81,11 @@ class CheckoutsController < CheckoutBaseController
         permitted_checkout_delivery_attributes
       )
     when :payment
-      massaged_params.require(:order).permit(
+      if @order.covered_by_store_credit?
+        massaged_params.fetch(:order, {})
+      else
+        massaged_params.require(:order)
+      end.permit(
         permitted_checkout_payment_attributes
       )
     else

--- a/templates/app/views/checkouts/steps/_payment_step.html.erb
+++ b/templates/app/views/checkouts/steps/_payment_step.html.erb
@@ -3,60 +3,63 @@
     <legend>
       <%= t('spree.payment_information') %>
     </legend>
+    <% if @order.covered_by_store_credit? %>
+      <p>Your order is fully covered by store credits, no additional payment method is required.</p>
+    <% else %>
+      <ul class="payment-step__selector">
+        <% @wallet_payment_sources&.each do |wallet_payment_source| %>
+          <% payment_method = wallet_payment_source.payment_source.payment_method %>
+          <% default = wallet_payment_source == @default_wallet_payment_source %>
+          <% fieldset_name = "wallet-source-#{wallet_payment_source.id}" %>
 
-    <ul class="payment-step__selector">
-      <% @wallet_payment_sources&.each do |wallet_payment_source| %>
-        <% payment_method = wallet_payment_source.payment_source.payment_method %>
-        <% default = wallet_payment_source == @default_wallet_payment_source %>
-        <% fieldset_name = "wallet-source-#{wallet_payment_source.id}" %>
+          <li>
+            <label>
+              <%= radio_button_tag(
+                "order[wallet_payment_source_id]",
+                wallet_payment_source.id,
+                default,
+                'data-action': 'checkout-payment#paymentSelected',
+                'data-checkout-payment-target': "paymentRadio",
+                'data-fieldset-name': fieldset_name,
+                id: ","
+              ) %>
+              <%= t(payment_method.name, scope: 'spree.payment_methods', default: payment_method.name) %>
+            </label>
+            <fieldset name="<%= fieldset_name %>" class="payment-step__details">
+              <%= render(
+                "checkouts/existing_payment/#{payment_method.partial_name}",
+                wallet_payment_source: wallet_payment_source,
+              ) %>
+            </fieldset>
+          </li>
+        <% end %>
 
-        <li>
-          <label>
-            <%= radio_button_tag(
-              "order[wallet_payment_source_id]",
-              wallet_payment_source.id,
-              default,
-              'data-action': 'checkout-payment#paymentSelected',
-              'data-checkout-payment-target': "paymentRadio",
-              'data-fieldset-name': fieldset_name,
-              id: ","
-            ) %>
-            <%= t(payment_method.name, scope: 'spree.payment_methods', default: payment_method.name) %>
-          </label>
-          <fieldset name="<%= fieldset_name %>" class="payment-step__details">
-            <%= render(
-              "checkouts/existing_payment/#{payment_method.partial_name}",
-              wallet_payment_source: wallet_payment_source,
-            ) %>
-          </fieldset>
-        </li>
-      <% end %>
+        <% @order.available_payment_methods.each.with_index do |payment_method, index| %>
+          <% default = !@default_wallet_payment_source && index.zero? %>
+          <% fieldset_name = "payment-method-#{payment_method.id}" %>
 
-      <% @order.available_payment_methods.each.with_index do |payment_method, index| %>
-        <% default = !@default_wallet_payment_source && index.zero? %>
-        <% fieldset_name = "payment-method-#{payment_method.id}" %>
-
-        <li>
-          <label>
-            <%= radio_button_tag(
-              "order[payments_attributes][][payment_method_id]",
-              payment_method.id,
-              default,
-              'data-action': 'checkout-payment#paymentSelected',
-              'data-checkout-payment-target': "paymentRadio",
-              'data-fieldset-name': fieldset_name,
-            ) %>
-            <%= t(payment_method.name, scope: 'spree.payment_method', default: payment_method.name) %>
-          </label>
-          <fieldset name="<%= fieldset_name %>" class="payment-step__details">
-            <%= render(
-              "checkouts/payment/#{payment_method.partial_name}",
-              payment_method: payment_method,
-            ) %>
-          </fieldset>
-        </li>
-      <% end %>
-    </ul>
+          <li>
+            <label>
+              <%= radio_button_tag(
+                "order[payments_attributes][][payment_method_id]",
+                payment_method.id,
+                default,
+                'data-action': 'checkout-payment#paymentSelected',
+                'data-checkout-payment-target': "paymentRadio",
+                'data-fieldset-name': fieldset_name,
+              ) %>
+              <%= t(payment_method.name, scope: 'spree.payment_method', default: payment_method.name) %>
+            </label>
+            <fieldset name="<%= fieldset_name %>" class="payment-step__details">
+              <%= render(
+                "checkouts/payment/#{payment_method.partial_name}",
+                payment_method: payment_method,
+              ) %>
+            </fieldset>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </fieldset>
 
   <%= button_tag(


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

Fixes #345

This PR adds logic to handle the checkout process for orders that are fully covered by store credits. 
In the checkout process, we skip the payment selection stage if the order can be entirely covered by store credits.
A message is displayed to the user indicating that no additional payment method is required.

These changes ensure a smoother checkout experience for users who have sufficient store credits to cover their entire order.

<img width="1045" alt="Screenshot 2023-06-29 at 14 52 19" src="https://github.com/solidusio/solidus_starter_frontend/assets/19948291/73aaf2da-985f-4913-a112-54b425f0fd5b">


<img width="1258" alt="Screenshot 2023-06-29 at 15 28 05" src="https://github.com/solidusio/solidus_starter_frontend/assets/19948291/aa648de3-d5d4-47fb-8b9b-7a5738c29bb0">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
