### PR TITLE
Remove the deprecated spec helper

### DIFF
--- a/templates/spec/solidus_starter_frontend_helper.rb
+++ b/templates/spec/solidus_starter_frontend_helper.rb
@@ -1,3 +1,0 @@
-warn "DEPRECATED: Please require 'solidus_starter_frontend_spec_helper' instead of 'solidus_starter_frontend_helper'.", uplevel: 1
-
-require 'solidus_starter_frontend_spec_helper'


### PR DESCRIPTION
## Summary

So it is not copied over applications on new installations.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
