### PR TITLE
Set a default screen size for the JS driver

### DIFF
--- a/templates/spec/support/solidus_starter_frontend/capybara.rb
+++ b/templates/spec/support/solidus_starter_frontend/capybara.rb
@@ -12,8 +12,9 @@ RSpec.configure do |config|
     driven_by((ENV['CAPYBARA_DRIVER'] || :rack_test).to_sym)
   end
 
-  config.before(:each, type: :system, js: true) do
-    driven_by((ENV['CAPYBARA_JS_DRIVER'] || :selenium_chrome_headless).to_sym)
+  config.before(:each, type: :system, js: true) do |example|
+    screen_size = example.metadata[:screen_size] || [1400, 1400]
+    driven_by((ENV['CAPYBARA_JS_DRIVER'] || :selenium_chrome_headless).to_sym, screen_size: screen_size)
   end
 end
 


### PR DESCRIPTION
## Summary

Set a default screen size for the JS driver and allow it to be overridden by the example metadata.


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
