### PR TITLE
Install tailwindcss

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails-sandbox server
+web: env RUBY_DEBUG_OPEN=true bin/rails server
 watch: bin/guard -i
+css: mkdir -p sandbox/app/assets/builds && touch sandbox/app/assets/builds/tailwind.css && bin/rails tailwindcss:watch

--- a/bin/dev
+++ b/bin/dev
@@ -5,5 +5,9 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
+if ! test -d sandbox; then
+  bin/sandbox
+fi
+
 export PORT=3000
 exec foreman start -f Procfile.dev "$@"

--- a/template.rb
+++ b/template.rb
@@ -69,6 +69,7 @@ with_log['installing gems'] do
   gem 'solidus_support'
   gem 'truncate_html'
   gem 'view_component', '~> 3.0'
+  gem 'tailwindcss-rails'
 
   gem_group :test do
     # We need to add capybara along with a javascript driver to support the provided system specs.
@@ -104,6 +105,7 @@ with_log['installing files'] do
 
   copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'
   copy_file 'config/initializers/canonical_rails.rb'
+  copy_file 'config/tailwind.config.js'
 
   append_file 'config/initializers/devise.rb', <<~RUBY
     Devise.setup do |config|

--- a/templates/app/assets/config/solidus_starter_frontend_manifest.js
+++ b/templates/app/assets/config/solidus_starter_frontend_manifest.js
@@ -1,2 +1,3 @@
 //= link solidus_starter_frontend.js
 //= link solidus_starter_frontend.css
+//= link tailwind.css

--- a/templates/app/assets/stylesheets/application.tailwind.css
+++ b/templates/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/templates/app/views/layouts/storefront.html.erb.tt
+++ b/templates/app/views/layouts/storefront.html.erb.tt
@@ -10,6 +10,7 @@
 
     <%%= javascript_include_tag 'solidus_starter_frontend' %>
     <%%= stylesheet_link_tag 'solidus_starter_frontend', media: 'screen' %>
+    <%%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
 
 <% if Rails.application.respond_to? :importmap -%>
     <%%= javascript_importmap_tags %>

--- a/templates/app/views/shared/search/_search_bar.html.erb
+++ b/templates/app/views/shared/search/_search_bar.html.erb
@@ -5,7 +5,7 @@
     "data-search-current-class": "autocomplete-results__item--current",
     "data-search-target": "form" do %>
 
-  <%= search_field_tag :keywords, params[:keywords], placeholder: "Search", class: "search-bar__input", autocomplete: "off",
+  <%= search_field_tag :keywords, params[:keywords], placeholder: "Search", class: "w-full border-0 border-b border-[#D8D8DD] text-[14px] focus:border-[#D8D8DD] focus:ring-0", autocomplete: "off",
     "data-action": "input->search#fetchResults
                     keydown.down->search#nextResult
                     keydown.up->search#previousResult

--- a/templates/config/tailwind.config.js
+++ b/templates/config/tailwind.config.js
@@ -1,0 +1,24 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,html}',
+    './app/components/**/*'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/aspect-ratio'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}

--- a/templates/config/tailwind.config.js
+++ b/templates/config/tailwind.config.js
@@ -15,6 +15,9 @@ module.exports = {
       },
     },
   },
+  corePlugins: {
+    preflight: false,
+  },
   plugins: [
     require('@tailwindcss/forms'),
     require('@tailwindcss/aspect-ratio'),


### PR DESCRIPTION
## Summary

Manually installs tailwindcss so the relevant config files are copied into the sandbox when running `bin/dev`.
Tailwind now is available. By just editing and saving the template files you'll see the results in the running sandbox.
In this pr I use tailwind to fix the search input style that was looking slightly different just after tailwind installation (on focus, a blue ring was shown around the search input field).
Even if this pr introduces tailwind it leaves the look completely untouched.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
