### PR TITLE
Automatically mount storefront where Solidus is mounted

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -105,6 +105,7 @@ with_log['installing files'] do
 
   copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'
   copy_file 'config/initializers/canonical_rails.rb'
+  copy_file 'config/routes/storefront.rb'
   copy_file 'config/tailwind.config.js'
   create_file 'app/assets/builds/tailwind.css'
 
@@ -150,74 +151,13 @@ with_log['installing files'] do
 end
 
 with_log['installing routes'] do
+  solidus_mount_point = Pathname(app_path).join('config', 'routes.rb').read[/mount Spree::Core::Engine, at: '([^']*)'/, 1]
+  solidus_mount_point ||= '/'
+
   # The default output is very noisy
   shell.mute do
     route <<~RUBY
-      root to: 'home#index'
-
-      devise_for(:user, {
-        class_name: 'Spree::User',
-        singular: :spree_user,
-        controllers: {
-          sessions: 'user_sessions',
-          registrations: 'user_registrations',
-          passwords: 'user_passwords',
-          confirmations: 'user_confirmations'
-        },
-        skip: [:unlocks, :omniauth_callbacks],
-        path_names: { sign_out: 'logout' }
-      })
-
-      resources :users, only: [:edit, :update]
-
-      devise_scope :spree_user do
-        get '/login', to: 'user_sessions#new', as: :login
-        post '/login', to: 'user_sessions#create', as: :create_new_session
-        match '/logout', to: 'user_sessions#destroy', as: :logout, via: Devise.sign_out_via
-        get '/signup', to: 'user_registrations#new', as: :signup
-        post '/signup', to: 'user_registrations#create', as: :registration
-        get '/password/recover', to: 'user_passwords#new', as: :recover_password
-        post '/password/recover', to: 'user_passwords#create', as: :reset_password
-        get '/password/change', to: 'user_passwords#edit', as: :edit_password
-        put '/password/change', to: 'user_passwords#update', as: :update_password
-        get '/confirm', to: 'user_confirmations#show', as: :confirmation if Spree::Auth::Config[:confirmable]
-      end
-
-      resource :account, controller: 'users'
-
-      resources :products, only: [:index, :show]
-
-      resources :autocomplete_results, only: :index
-
-      resources :cart_line_items, only: :create
-
-      get '/locale/set', to: 'locale#set'
-      post '/locale/set', to: 'locale#set', as: :select_locale
-
-      resource :checkout_session, only: :new
-      resource :checkout_guest_session, only: :create
-
-      # non-restful checkout stuff
-      patch '/checkout/update/:state', to: 'checkouts#update', as: :update_checkout
-      get '/checkout/:state', to: 'checkouts#edit', as: :checkout_state
-      get '/checkout', to: 'checkouts#edit', as: :checkout
-
-      get '/orders/:id/token/:token' => 'orders#show', as: :token_order
-
-      resources :orders, only: :show do
-        resources :coupon_codes, only: :create
-      end
-
-      resource :cart, only: [:show, :update] do
-        put 'empty'
-      end
-
-      # route globbing for pretty nested taxon and product paths
-      get '/t/*id', to: 'taxons#show', as: :nested_taxons
-
-      get '/unauthorized', to: 'home#unauthorized', as: :unauthorized
-      get '/cart_link', to: 'store#cart_link', as: :cart_link
-
+      scope(path: '#{solidus_mount_point}') { draw :storefront }
     RUBY
   end
 

--- a/templates/config/routes/storefront.rb
+++ b/templates/config/routes/storefront.rb
@@ -1,0 +1,64 @@
+root to: 'home#index'
+
+devise_for(:user, {
+  class_name: 'Spree::User',
+  singular: :spree_user,
+  controllers: {
+    sessions: 'user_sessions',
+    registrations: 'user_registrations',
+    passwords: 'user_passwords',
+    confirmations: 'user_confirmations'
+  },
+  skip: [:unlocks, :omniauth_callbacks],
+  path_names: { sign_out: 'logout' }
+})
+
+resources :users, only: [:edit, :update]
+
+devise_scope :spree_user do
+  get '/login', to: 'user_sessions#new', as: :login
+  post '/login', to: 'user_sessions#create', as: :create_new_session
+  match '/logout', to: 'user_sessions#destroy', as: :logout, via: Devise.sign_out_via
+  get '/signup', to: 'user_registrations#new', as: :signup
+  post '/signup', to: 'user_registrations#create', as: :registration
+  get '/password/recover', to: 'user_passwords#new', as: :recover_password
+  post '/password/recover', to: 'user_passwords#create', as: :reset_password
+  get '/password/change', to: 'user_passwords#edit', as: :edit_password
+  put '/password/change', to: 'user_passwords#update', as: :update_password
+  get '/confirm', to: 'user_confirmations#show', as: :confirmation if Spree::Auth::Config[:confirmable]
+end
+
+resource :account, controller: 'users'
+
+resources :products, only: [:index, :show]
+
+resources :autocomplete_results, only: :index
+
+resources :cart_line_items, only: :create
+
+get '/locale/set', to: 'locale#set'
+post '/locale/set', to: 'locale#set', as: :select_locale
+
+resource :checkout_session, only: :new
+resource :checkout_guest_session, only: :create
+
+# non-restful checkout stuff
+patch '/checkout/update/:state', to: 'checkouts#update', as: :update_checkout
+get '/checkout/:state', to: 'checkouts#edit', as: :checkout_state
+get '/checkout', to: 'checkouts#edit', as: :checkout
+
+get '/orders/:id/token/:token' => 'orders#show', as: :token_order
+
+resources :orders, only: :show do
+  resources :coupon_codes, only: :create
+end
+
+resource :cart, only: [:show, :update] do
+  put 'empty'
+end
+
+# route globbing for pretty nested taxon and product paths
+get '/t/*id', to: 'taxons#show', as: :nested_taxons
+
+get '/unauthorized', to: 'home#unauthorized', as: :unauthorized
+get '/cart_link', to: 'store#cart_link', as: :cart_link


### PR DESCRIPTION
## Summary

Right now, no matter where Solidus is mounted, the storefront will live at the root of the application.

Most of the times, this is not the expected behavior because if Solidus lives at /store for example, the user probably also wants the storefront to live at that path.

This change will change the install template to detect where Solidus has been mounted and use that path as the scope of the routes.

Grouping the routes in a scope and in a separate file has the advantage to have all the injected routes isolated, which might help with having a clearer routes file in the application. On the other hand, when Solidus is mounted at /, the scope is useless and might be avoided, but I think we can live with that.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
