### PR TITLE
Restore specs on the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
         default: 'main'
       rails_version:
         type: string
-        default: '~> 7.0'
+        default: '~> 7.0.0'
       ruby_version:
         type: string
       database:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ workflows:
       - run-specs:
           name: run-specs-with-postgres-ruby-3-0
           database: 'postgres'
-          ruby_version: '2.7'
+          ruby_version: '3.0'
 
       - run-specs:
           name: run-specs-with-mysql-ruby-3-2

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0'
+gem 'rails', ENV['RAILS_VERSION'] || '~> 7.0.0'
 
 group :development do
   gem 'guard'


### PR DESCRIPTION
## Summary

CI is currently not executing any spec, because Solidus is not installed (due to the Rails 7.1 incompatibility) and its specs are not copied over the sandbox application. 

Tests were green because there were no tests, so no failures.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
