### PR TITLE
Use a number field for cart item quantity

### DIFF
--- a/templates/app/views/cart_line_items/_product_submit.html.erb
+++ b/templates/app/views/cart_line_items/_product_submit.html.erb
@@ -2,8 +2,8 @@
   <%= render 'cart_line_items/product_availability', product: product %>
 
   <div class="flex items-center justify-start gap-x-7">
-    <div class="select-input">
-      <%= select_tag("quantity", options_for_select((1..product.total_on_hand).to_a, 1), class: 'min-w-[100px]', :onchange => "addToCartButtonPriceChangeHandler('#{product.price}')") %>
+    <div class="text-input">
+      <%= number_field_tag "quantity", 1, step: 1, class: 'min-w-[100px]', :onchange => "addToCartButtonPriceChangeHandler('#{product.price}')" %>
     </div>
     <% cta_label = content_tag(:span, "#{t('spree.add_to_cart')} — ") + content_tag(:span, display_price(product), id: 'cta_price') %>
     <%= render partial: "shared/call_to_action", :locals => { :label => cta_label, :id => 'add-to-cart-button', :url => nil } %>

--- a/templates/app/views/carts/_cart_item.html.erb
+++ b/templates/app/views/carts/_cart_item.html.erb
@@ -26,19 +26,19 @@
 
     <div class="flex flex-row-reverse justify-between col-span-full sm:col-span-4 sm:flex-col">
       <div class="flex items-center justify-between w-full">
-        <div class="cart-item__quantity select-input [&>select]:min-w-[100px]">
-          <%= item_form.select :quantity, (0..variant.total_on_hand).to_a %>
+        <div class="cart-item__quantity text-input mr-4">
+          <%= item_form.number_field :quantity %>
         </div>
-        
+
         <div class="cart-item__price hidden md:block col-span-2">
           <p class="font-sans-md"><%= line_item.display_amount.to_html unless line_item.quantity.nil? %></p>
         </div>
-        
+
         <div class="flex items-center justify-end md:hidden gap-x-2">
           <%= render 'carts/cart_item_remove', order_form: order_form, item_form: item_form, line_item: line_item %>
         </div>
       </div>
-      
+
       <div class="hidden md:flex items-center justify-end gap-x-2">
         <%= render 'carts/cart_item_remove', order_form: order_form, item_form: item_form, line_item: line_item %>
       </div>

--- a/templates/spec/system/automatic_promotion_adjustments_spec.rb
+++ b/templates/spec/system/automatic_promotion_adjustments_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe 'Automatic promotions', type: :system, js: true do
     end
 
     it "automatically applies the promotion once the order crosses the threshold" do
-      select 6, from: "order_line_items_attributes_0_quantity"
+      fill_in "order_line_items_attributes_0_quantity", with: 6
       click_button "Update"
       expect(page).to have_content("Promotion ($10 off when you spend more than $100) -$10.00", normalize_ws: true)
 
-      select 5, from: "order_line_items_attributes_0_quantity"
+      fill_in "order_line_items_attributes_0_quantity", with: 5
       click_button "Update"
       expect(page).not_to have_content("Promotion ($10 off when you spend more than $100) -$10.00", normalize_ws: true)
     end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe 'Checkout', :js, type: :system do
         stock_location.stock_items.update_all(count_on_hand: 5)
         visit cart_path
         within '.cart-item__quantity' do
-          select 3, from: "order_line_items_attributes_0_quantity"
+          fill_in "order_line_items_attributes_0_quantity", with: 3
         end
 
         click_on "Update"

--- a/templates/spec/system/coupon_code_spec.rb
+++ b/templates/spec/system/coupon_code_spec.rb
@@ -191,8 +191,8 @@ RSpec.describe 'Coupon code promotions', type: :system, js: true do
           fill_in "coupon_code", with: "onetwo"
           click_button "Apply Code"
 
-          select "2", from: "order_line_items_attributes_0_quantity"
-          select "2", from: "order_line_items_attributes_1_quantity"
+          fill_in "order_line_items_attributes_0_quantity", with: 2
+          fill_in "order_line_items_attributes_1_quantity", with: 2
           click_button "Update"
 
           within '#cart_adjustments' do
@@ -245,8 +245,8 @@ RSpec.describe 'Coupon code promotions', type: :system, js: true do
             expect(page).to have_content("$0.00")
           end
 
-          select "2", from: "order_line_items_attributes_0_quantity"
-          select "2", from: "order_line_items_attributes_1_quantity"
+          fill_in "order_line_items_attributes_0_quantity", with: 2
+          fill_in "order_line_items_attributes_1_quantity", with: 2
           click_button "Update"
 
           within '#cart_adjustments' do

--- a/templates/spec/system/promotion_code_invalidation_spec.rb
+++ b/templates/spec/system/promotion_code_invalidation_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe 'Promotion Code Invalidation', type: :system, js: true do
     end
 
     # Remove an item
-    select '0', from: "order_line_items_attributes_0_quantity"
+
+    fill_in "order_line_items_attributes_0_quantity", with: 0
     click_button "Update"
     within("#cart_adjustments") do
       expect(page).to have_content("-$5.00")

--- a/templates/spec/system/quantity_promotions_spec.rb
+++ b/templates/spec/system/quantity_promotions_spec.rb
@@ -44,19 +44,20 @@ RSpec.describe 'Quantity Promotions', type: :system, js: true do
     end
 
     # Reduce quantity by 1, making promotion not apply.
-    select "1", from: "order_line_items_attributes_0_quantity"
+
+    fill_in "order_line_items_attributes_0_quantity", with: 1
     click_button "Update"
     expect(page).to_not have_content("#cart_adjustments")
 
     # Bump quantity to 3, making promotion apply "once."
-    select "3", from: "order_line_items_attributes_0_quantity"
+    fill_in "order_line_items_attributes_0_quantity", with: 3
     click_button "Update"
     within("#cart_adjustments") do
       expect(page).to have_content("-$10.00")
     end
 
     # Bump quantity to 4, making promotion apply "twice."
-    select "4", from: "order_line_items_attributes_0_quantity"
+    fill_in "order_line_items_attributes_0_quantity", with: 4
     click_button "Update"
     within("#cart_adjustments") do
       expect(page).to have_content("-$20.00")
@@ -66,7 +67,7 @@ RSpec.describe 'Quantity Promotions', type: :system, js: true do
   # Catches an earlier issue with quantity calculation.
   it 'adding odd numbers of items to the cart' do
     # Bump quantity to 3
-    select "3", from: "order_line_items_attributes_0_quantity"
+    fill_in "order_line_items_attributes_0_quantity", with: 3
     click_button "Update"
 
     # Apply the promo code and see a $10 discount (for 2 of the 3 items)
@@ -100,7 +101,7 @@ RSpec.describe 'Quantity Promotions', type: :system, js: true do
     before { FactoryBot.create(:product, name: 'DC-15A') }
 
     it 'odd number of changes to quantities' do
-      select "3", from: "order_line_items_attributes_0_quantity"
+      fill_in "order_line_items_attributes_0_quantity", with: 3
       click_button "Update"
 
       # Apply the promo code and see a $15 discount
@@ -120,7 +121,7 @@ RSpec.describe 'Quantity Promotions', type: :system, js: true do
       end
 
       # Reduce quantity of first item to 2
-      select "2", from: "order_line_items_attributes_0_quantity"
+      fill_in "order_line_items_attributes_0_quantity", with: 2
       click_button "Update"
       within("#cart_adjustments") do
         expect(page).to have_content("-$15.00")

--- a/templates/spec/system/quantity_promotions_spec.rb
+++ b/templates/spec/system/quantity_promotions_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Quantity Promotions', type: :system, js: true do
     # Add a different product to our cart with quantity of 2.
     visit products_path
     click_link "E-11"
-    select "2", from: "quantity"
+    fill_in "quantity", with: 2
     click_button "Add To Cart"
 
     # We now have 5 items total, so discount should increase.


### PR DESCRIPTION

## Summary

Selects for numbers are a bad idea. It is possible for our variants to have a `count_on_hand` of Infinity (by unchecking the "track inventory" checkbox. On my machine (32G memory), this took about ten minutes to fill up  my memory.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
