### PR TITLE
Fix (Cart): Use dynamic type for display

### DIFF
--- a/templates/app/views/carts/_cart_adjustment.html.erb
+++ b/templates/app/views/carts/_cart_adjustment.html.erb
@@ -8,7 +8,7 @@
 <% if adjustments_sum != 0 %>
   <%= render(
     "carts/cart_amount_row",
-    type: t('spree.tax'),
+    type: type,
     label: label,
     amount: Spree::Money.new(adjustments_sum, currency: @order.currency)
   ) %>


### PR DESCRIPTION


## Summary

Without this fix, all adjustments, even if they are promotion adjustments, are displayed as "Tax".

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
