### PR TITLE
Coupon Codes Controller: Use new extension point

### DIFF
--- a/templates/app/controllers/coupon_codes_controller.rb
+++ b/templates/app/controllers/coupon_codes_controller.rb
@@ -9,7 +9,7 @@ class CouponCodesController < StoreController
 
     if params[:coupon_code].present?
       @order.coupon_code = params[:coupon_code]
-      handler = Spree::Config.coupon_code_handler_class.new(@order).apply
+      handler = Spree::Config.promotions.coupon_code_handler_class.new(@order).apply
 
       respond_to do |format|
         format.html do


### PR DESCRIPTION


## Summary

The extension point for the coupon code handler class has been moved to the configurable promotions object.
Removes a lot of deprecation warnings from the test suite.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
