### PR TITLE
fix image display issue

### DIFF
--- a/templates/app/views/home/_featured_products.html.erb
+++ b/templates/app/views/home/_featured_products.html.erb
@@ -1,13 +1,13 @@
 <section class="wrapper pt-3 pb-14 md:pb-24">
   <div class="grid-container">
     <div class="col-span-full md:col-span-8 md:max">
-      <%= render 'products/featured_product_card', { product: products[0], size: 'big' } %>
+      <%= render 'products/featured_product_card', { product: products[0], size: :big } %>
     </div>
     <div class="col-span-full flex flex-col gap-y-6 md:col-span-4">
       <% products.each_with_index do |product, index| %>
         <% if index > 0 %>
           <div class="basis-1/2">
-            <%= render 'products/featured_product_card', { product: product, size: 'small' } %>
+            <%= render 'products/featured_product_card', { product: product, size: :small } %>
           </div>
         <% end %>
       <% end %>


### PR DESCRIPTION
product images (starter frontend homepage) don't display properly because the size property isn't correct.
before:
![Screenshot from 2024-07-29 20-01-27](https://github.com/user-attachments/assets/48704a76-785e-4d9f-bffc-f77c66d0db4b)
after:
![Screenshot from 2024-07-29 20-00-56](https://github.com/user-attachments/assets/5866a604-6d52-4d0c-80df-912f52f86514)

Should have corresponding size in config->initializers->spree.rb or use solidus default size
For example:
```
Spree.config do |config|
  # ...
  config.product_image_styles = {
    mini: "48x48>",
    small: "400x400>",
    big: "680x680>",
    product: "680x680>",
    large: "1200x1200>",
    full: "1600x1600>",
    jumbo: "1600x1600>"
  }
end
```
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
