### PR TITLE
Use config.assets.prefix for asset paths in a spec

### DIFF
--- a/templates/spec/components/image_component_spec.rb
+++ b/templates/spec/components/image_component_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe ImageComponent, type: :component do
   let(:page_image) { page.find('img') }
 
   context 'when rendered' do
+    def assets_prefix
+      @assets_prefix ||= Rails.application.config.assets.prefix
+    end
+
     before do
       render_inline(described_class.new(arguments))
     end
@@ -26,7 +30,7 @@ RSpec.describe ImageComponent, type: :component do
 
         it 'renders the image' do
           expect(page_image['alt']).to eq(alt)
-          expect(page_image['src']).to match(%r{/assets/noimage/mini-.*.png})
+          expect(page_image['src']).to match(%r{#{assets_prefix}/noimage/mini-.*.png})
         end
       end
 
@@ -35,7 +39,7 @@ RSpec.describe ImageComponent, type: :component do
 
         it 'renders the image' do
           expect(page_image['alt']).to be_nil
-          expect(page_image['src']).to match(%r{/assets/noimage/mini-.*.png})
+          expect(page_image['src']).to match(%r{#{assets_prefix}/noimage/mini-.*.png})
         end
       end
     end
@@ -55,7 +59,7 @@ RSpec.describe ImageComponent, type: :component do
         expect(page_image['class']).to eq('some-class')
         expect(page_image['itemprop']).to eq('some-itemprop')
         expect(page_image['data-key']).to eq('value')
-        expect(page_image['src']).to match(%r{/assets/noimage/small-.*.png})
+        expect(page_image['src']).to match(%r{#{assets_prefix}/noimage/small-.*.png})
       end
     end
   end


### PR DESCRIPTION
## Summary

Sometimes, assets path differ from `/assets`, so it's better not to hardcode it in tests.
Using `Rails.application.config.assets.prefix` instead


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x ] I have written a thorough PR description.
- [x ] I have kept my commits small and atomic.
- [x ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
