### PR TITLE
Fix installing in fresh Rails app with Stimulus

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -101,7 +101,7 @@ with_log['installing gems'] do
 end
 
 with_log['installing files'] do
-  directory 'app', 'app', verbose: false
+  directory 'app', 'app', verbose: auto_accept, force: auto_accept
   directory 'public', 'public'
 
   copy_file 'config/initializers/solidus_auth_devise_unauthorized_redirect.rb'

--- a/templates/spec/support/solidus_starter_frontend/capybara.rb
+++ b/templates/spec/support/solidus_starter_frontend/capybara.rb
@@ -14,7 +14,9 @@ RSpec.configure do |config|
 
   config.before(:each, type: :system, js: true) do |example|
     screen_size = example.metadata[:screen_size] || [1800, 1400]
-    driven_by :selenium, using: :headless_chrome, screen_size: screen_size
+    driven_by(:selenium, using: :headless_chrome, screen_size: screen_size) do |capabilities|
+      capabilities.add_argument("--disable-search-engine-choice-screen")
+    end
   end
 end
 
@@ -22,6 +24,7 @@ Capybara.register_driver :selenium_chrome_headless_docker_friendly do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
+  browser_options.args << '--disable-search-engine-choice-screen'
   # Sandbox cannot be used inside unprivileged Docker container
   browser_options.args << '--no-sandbox'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)


### PR DESCRIPTION
## Summary

Fresh Rails apps with Stimulus installed already have a `app/javascript/controller/index.js` file with boilerplate code. Since we install this file as well we need to overwrite it if auto accept is enabled.

Example of failing build in Solidus core https://app.circleci.com/pipelines/github/solidusio/solidus/6567/workflows/570ef440-07cb-470a-bb91-9f08ba79c1de/jobs/60769

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
