### PR TITLE
fix: bin/sandbox command

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -28,7 +28,7 @@ export BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES=true
 
 rm -rf ./sandbox
 rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new sandbox \
+bundle exec rails _${rails_version}_ new sandbox \
   --skip-git \
   --database=${DB:-sqlite3} \
   --skip-rc


### PR DESCRIPTION
Use `bundle exec` to invoke the rails installer,
otherwise it will fail with

```
/Users/<user>/.rubies/ruby-3.3.5/lib/ruby/3.3.0/rubygems.rb:259:in `find_spec_for_exe': can't find gem rails (= 7.2.1.1) with executable rails (Gem::GemNotFoundException)
        from /Users/<user>/.rubies/ruby-3.3.5/lib/ruby/3.3.0/rubygems.rb:278:in `activate_bin_path'
        from /Users/<user>/.gem/ruby/3.3.5/bin/rails:25:in `<main>'
```

although it is installed.
