### PR TITLE
#382 Replace hardcoded labels with i18 translations on my account page

### DIFF
--- a/templates/app/views/users/edit.html.erb
+++ b/templates/app/views/users/edit.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/error_messages', target: @user %>
 
   <div class="col-span-full space-y-4">
-    <h1 class="font-serif text-h4 md:text-h3">My account</h1>
+    <h1 class="font-serif text-h4 md:text-h3"><%= I18n.t('spree.my_account') %></h1>
     <div class="flex flex-wrap flex-auto gap-4">
       <%= @user.email %>
       <%= form_with(url: logout_path, method: Devise.sign_out_via, local: true) do %>

--- a/templates/app/views/users/show.html.erb
+++ b/templates/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
 
 <div class="wrapper grid-container py-12 space-y-10 md:space-y-14">
   <div class="col-span-full space-y-4">
-    <h1 class="font-serif text-h4 md:text-h3">My account</h1>
+    <h1 class="font-serif text-h4 md:text-h3"><%= I18n.t('spree.my_account') %></h1>
     <div class="flex flex-wrap flex-auto gap-4">
       <%= @user.email %>
       <%= form_with(url: logout_path, method: Devise.sign_out_via, local: true) do %>


### PR DESCRIPTION
## Summary

"My Account" was not translated in front-end despite string being present. 

Fixes #382 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
