### PR TITLE
Fix fontfamily classes

### DIFF
--- a/templates/config/tailwind.config.js
+++ b/templates/config/tailwind.config.js
@@ -20,8 +20,8 @@ module.exports = {
     fontFamily: {
       sans: ['Inter Regular', 'system-ui', 'sans-serif'],
       'sans-md': ['"Inter Medium"', 'system-ui', 'sans-serif'],
-      serif: ['Source Serif', 'system-ui', 'sans-serif'],
-      'serif-md': ['"Source Serif Medium"', 'system-ui', 'sans-serif'],
+      serif: ['Source Serif', 'system-ui', 'serif'],
+      'serif-md': ['"Source Serif Medium"', 'system-ui', 'serif'],
     },
     fontSize: {
       h1: ['4rem', '120%'],


### PR DESCRIPTION
serif and serif-md where loading wrong fallback system font classes

## Summary

Hey, on testing I noticed I missed the fall back font classes. This is the final final PR for the font issues. 

  Fixes #379 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
