### PR TITLE
Use at least solidus_support 0.12.0

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -66,7 +66,7 @@ with_log['installing gems'] do
 
   gem 'responders'
   gem 'canonical-rails'
-  gem 'solidus_support'
+  gem 'solidus_support', '>= 0.12.0'
   gem 'truncate_html'
   gem 'view_component', '~> 3.0'
   gem 'tailwindcss-rails'


### PR DESCRIPTION
solidus_support 0.11.0 introduced flickwerk for patch loading. Somehow this messes with the zeitwerk autoloader and things acting weird (inflections broken, wrong constant module nesting, etc.)

0.12.0 reverted flickwerk.
