### PR TITLE
Allow to skip frontend specs from extensions

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -145,7 +145,13 @@ with_log['installing files'] do
     end
   RUBY
 
-  directory 'spec', verbose: false
+  # Allows to skip frontend specs generation from extensions CI pipelines
+  if ENV.fetch("FRONTEND_SPECS", "all") == "all"
+    directory 'spec', verbose: false
+  else
+    # This file is always necessary in order to run frontend specs from extensions
+    copy_file 'spec/solidus_starter_frontend_spec_helper.rb', verbose: auto_accept, force: auto_accept
+  end
 
   # In CI, the Rails environment is test. In that Rails environment,
   # `Solidus::InstallGenerator#setup_assets` adds `solidus_frontend` assets to


### PR DESCRIPTION
## Summary

When we test extensions with the new starter frontend we run this template to generate the dummy app. This template also installs all frontend specs. This leads to unnecessary long build times, flaky sepcs and simply wastes a lot of resources.

Since the extension tests it's own behavior in the dummy app we simply must not duplicate every single spec we also test in this repo.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
