### PR TITLE
Added missing Boilerplate License for legal compliance

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -24,6 +24,8 @@ with_log['checking versions'] do
 end
 
 # Copied from: https://github.com/mattbrictson/rails-template
+# Copyright (c) 2023 Matt Brictson
+# Licensed under the terms of the MIT License (MIT)
 # Add this template directory to source_paths so that Thor actions like
 # copy_file and template resolve against our source files. If this file was
 # invoked remotely via HTTP, that means the files are not present locally.


### PR DESCRIPTION
Integrate correct copyright of 3rd party code used

## Summary

Code used from https://github.com/mattbrictson/rails-template?tab=MIT-1-ov-file#readme
was not attributed correctly.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
