### PR TITLE
Fixes background of featured product

### DIFF
--- a/templates/app/views/products/_featured_product_card.html.erb
+++ b/templates/app/views/products/_featured_product_card.html.erb
@@ -1,4 +1,4 @@
-<div class="relative bg-gray-50 overflow-hidden rounded-lg md:rounded-xl lg:rounded-2xl">
+<div class="relative bg-black overflow-hidden rounded-lg md:rounded-xl lg:rounded-2xl">
   <% image = product.gallery.images.second || product.gallery.images.first %>
   <%= render(ImageComponent.new(
     image: image,


### PR DESCRIPTION
## Summary

Reverts a change upon initial changing the color of the featured image background to a light grey rendering product name unreadable. This commit reverts the color to the Solidus Demo.  

Screenshot Current: 
<img width="862" alt="Screenshot 2025-01-30 at 11 27 14" src="https://github.com/user-attachments/assets/4644d6a8-80ce-4e4a-b229-0d36095103c4" />

Screenshot Demo: 
<img width="865" alt="Screenshot 2025-01-30 at 11 27 20" src="https://github.com/user-attachments/assets/0c4b59aa-bf08-4af4-876c-696b2942b49e" />


Fixes: #411 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
