### PR TITLE
Add condition to handle redirects for taxon permalink

### DIFF
--- a/templates/app/controllers/taxons_controller.rb
+++ b/templates/app/controllers/taxons_controller.rb
@@ -15,7 +15,8 @@ class TaxonsController < StoreController
   private
 
   def load_taxon
-    @taxon = Spree::Taxon.find_by!(permalink: params[:id])
+    @taxon = Spree::Taxon.friendly.find(params[:id])
+    redirect_to nested_taxons_path(@taxon), status: :moved_permanently if params[:id] != @taxon.permalink
   end
 
   def accurate_title

--- a/templates/spec/controllers/taxons_controller_spec.rb
+++ b/templates/spec/controllers/taxons_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'solidus_starter_frontend_spec_helper'
+
+RSpec.describe TaxonsController, type: :controller do
+  describe 'GET #show' do
+    let!(:taxon) { create(:taxon, permalink: "test") }
+    let!(:old_param) { taxon.permalink }
+
+    before do
+      taxon.update(permalink: 'new-sample-product')
+    end
+
+    context 'when permalink matches id param' do
+      it 'does not redirect' do
+        get :show, params: { id: taxon.permalink }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when old slug is passed' do
+      it 'redirects to the correct product path' do
+        get :show, params: { id: old_param }
+
+        expect(response).to redirect_to(nested_taxons_path(taxon))
+        expect(response.status).to eq(301)
+      end
+    end
+
+    context 'when slug does not match id param and product does not exist' do
+      it 'returns 404' do
+        expect do
+          get :show, params: { id: 'non-existent-slug' }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR modifies the `TaxonsController` to enhance permalink handling by implementing a redirect when an outdated permalink is requested. The update ensures that if a user visits a taxon page with an old slug, they are redirected to the new one.

#### Changes:
- **Controller**: 
  - In the `TaxonsController`, the `load_taxon` method now uses `Spree::Taxon.friendly.find` to find the taxon by its friendly permalink (slug).
  - Added a redirect to the updated taxon path if the requested permalink does not match the current one, returning a `301 Moved Permanently` status.

- **Tests**:
  - Added controller tests for the `show` action to verify:
    - No redirect happens when the requested permalink matches the current one.
    - A redirect occurs when an old permalink is used.
    - A `404 Not Found` error is raised when a non-existent permalink is requested.

### Motivation
This change ensures that links to old slugs (permalinks) are properly redirected to the correct page, improving SEO and maintaining a good user experience.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
