### PR TITLE
Pass in line item to item_info instead of product

### DIFF
--- a/templates/app/views/orders/_order_item.html.erb
+++ b/templates/app/views/orders/_order_item.html.erb
@@ -13,7 +13,7 @@
     <div class="flex flex-col gap-y-2 lg:pt-3">
       <%= render(
         'orders/item_info',
-        line_item: item.variant.product,
+        line_item: item,
         stock_info: false,
         variant: item.variant,
         classes: ["!gap-y-2 [&>h3]:text-body [&>h3]:font-sans-md"]


### PR DESCRIPTION
## Summary

I noticed we were passing in the wrong thing into this partial. It worked if the stock_info variable was set to false but would error otherwise. No changes are needed to the partial. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
