### PR TITLE
fix typo in authentication specs

### DIFF
--- a/templates/spec/system/authentication/sign_in_spec.rb
+++ b/templates/spec/system/authentication/sign_in_spec.rb
@@ -4,7 +4,7 @@ require 'solidus_starter_frontend_spec_helper'
 
 RSpec.feature 'Sign In', type: :system do
   include_context "featured products"
-  
+
   background do
     @user = create(:user, email: 'email@person.com', password: 'secret', password_confirmation: 'secret')
     visit login_path
@@ -21,7 +21,7 @@ RSpec.feature 'Sign In', type: :system do
     expect(current_path).to eq '/'
   end
 
-  scenario 'show validation erros' do
+  scenario 'show validation errors' do
     fill_in 'Email', with: @user.email
     fill_in 'Password:', with: 'wrong_password'
     click_button 'Login'


### PR DESCRIPTION
## Summary

fixes spelling in scenario name for sign in authentication spec:
'show validation erros' -> 'show validation erro**r**s'

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
