### PR TITLE
Switch to flickwerk for loading patches

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -66,10 +66,11 @@ with_log['installing gems'] do
     generate 'solidus:auth:install'
   end
 
+  gem "flickwerk", "~> 0.3.5"
   gem 'responders'
   gem 'solidus_support', '>= 0.12.0'
-  gem 'view_component', '~> 3.0'
   gem 'tailwindcss-rails', '~> 3.0'
+  gem 'view_component', '~> 3.0'
 
   gem_group :test do
     # We need to add capybara along with a javascript driver to support the provided system specs.
@@ -120,6 +121,8 @@ with_log['installing files'] do
   RUBY
 
   application <<~RUBY
+    include Flickwerk
+    
     if defined?(FactoryBotRails)
       initializer after: "factory_bot.set_factory_paths" do
         require 'spree/testing_support/factory_bot'

--- a/templates/app/patches/models/product_featured_similar_products_patch.rb
+++ b/templates/app/patches/models/product_featured_similar_products_patch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ProductFeaturedSimilarProducts
+module ProductFeaturedSimilarProductsPatch
   def self.prepended(base)
     base.scope :featured, -> { where(featured: true) }
   end

--- a/templates/app/patches/models/taxon_custom_queries_patch.rb
+++ b/templates/app/patches/models/taxon_custom_queries_patch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module TaxonCustomQueries
+module TaxonCustomQueriesPatch
   def featured(limit = 3)
     all_products.featured.order('RANDOM()').limit(limit)
   end


### PR DESCRIPTION
## Summary

Solidus has moved to using `app/patches` for monkey patching core classes using the flickwerk gem. This change updates the starter frontend to be consistent with that.

This commit closes https://github.com/solidusio/solidus_starter_frontend/issues/427 and should resolve the issue here: https://github.com/solidusio/solidus/issues/4877

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
