### PR TITLE
Update to rubocop-rspec 3

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -94,7 +94,7 @@ with_log['installing gems'] do
     gem 'rubocop', '~> 1.0'
     gem 'rubocop-performance', '~> 1.5'
     gem 'rubocop-rails', '~> 2.3'
-    gem 'rubocop-rspec', '~> 2.0'
+    gem 'rubocop-rspec', '~> 3.0'
   end
 
   run_bundle


### PR DESCRIPTION


## Summary

There is an issue running bin/rake where it errors with "Passing a project root directory to `inject_defaults!` is no longer supported." rubocop-rspec 2.x does this but version 3 does not so updating fixes the issue. We don't specifically reference any of the rubocop departments so no changes need to be made to make this upgrade. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
