### PR TITLE
Remove calls to eligible on adjustments

### DIFF
--- a/templates/app/views/carts/_cart_adjustments.html.erb
+++ b/templates/app/views/carts/_cart_adjustments.html.erb
@@ -6,7 +6,7 @@
   ) %>
 
   <% if @order.line_item_adjustments.exists? %>
-    <% @order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+    <% @order.line_item_adjustments.promotion.group_by(&:label).each do |label, adjustments| %>
       <% if adjustments.sum(&:amount) != 0 %>
         <%= render(
           "cart_adjustment",
@@ -18,7 +18,7 @@
     <% end %>
   <% end %>
 
-  <% @order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
+  <% @order.all_adjustments.tax.group_by(&:label).each do |label, adjustments| %>
     <%= render(
       "carts/cart_adjustment",
       type: t('spree.tax'),
@@ -36,7 +36,7 @@
     ) %>
   <% end %>
 
-  <% @order.adjustments.eligible.group_by(&:label).each do |label, adjustments| %>
+  <% @order.adjustments.group_by(&:label).each do |label, adjustments| %>
     <%= render(
       "carts/cart_adjustment",
       type: t('spree.adjustment'),

--- a/templates/app/views/checkouts/_checkout_summary.html.erb
+++ b/templates/app/views/checkouts/_checkout_summary.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <% if order.line_item_adjustments.nonzero.exists? %>
-        <% order.line_item_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+        <% order.line_item_adjustments.nonzero.promotion.group_by(&:label).each do |label, adjustments| %>
           <div class="checkout-summary__entry <%= dl_classes %>">
             <dt><%= label %></dt>
             <dd><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></dd>
@@ -27,7 +27,7 @@
         <% end %>
       <% end %>
 
-      <% order.all_adjustments.nonzero.tax.eligible.group_by(&:label).each do |label, adjustments| %>
+      <% order.all_adjustments.nonzero.tax.group_by(&:label).each do |label, adjustments| %>
         <div class="checkout-summary__entry <%= dl_classes %>">
           <dt><%= label %></dt>
           <dd><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></dd>
@@ -41,7 +41,7 @@
         </div>
 
         <% if order.shipment_adjustments.nonzero.exists? %>
-          <% order.shipment_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+          <% order.shipment_adjustments.nonzero.promotion.group_by(&:label).each do |label, adjustments| %>
             <div class="checkout-summary__entry <%= dl_classes %>">
               <dt><%= label %>:</dt>
               <dd><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></dd>
@@ -50,9 +50,9 @@
         <% end %>
       <% end %>
 
-      <% if order.adjustments.nonzero.non_tax.eligible.exists? %>
+      <% if order.adjustments.nonzero.non_tax.exists? %>
         <div class="checkout-summary__entry <%= dl_classes %> font-sans-md" id="summary-order-charges">
-          <% order.adjustments.nonzero.non_tax.eligible.each do |adjustment| %>
+          <% order.adjustments.nonzero.non_tax.each do |adjustment| %>
             <dt><%= adjustment.label %>:</dt>
             <dd class="text-primary"><%= adjustment.display_amount.to_html %></dd>
           <% end %>

--- a/templates/app/views/orders/_line_items.html.erb
+++ b/templates/app/views/orders/_line_items.html.erb
@@ -17,9 +17,9 @@
   </div>
 
   <% if order.line_item_adjustments.exists? %>
-    <% if order.line_item_adjustments.promotion.eligible.exists? %>
+    <% if order.line_item_adjustments.promotion.exists? %>
       <div id="price-adjustments" class="<%= line_class_names %>">
-        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+        <% order.line_item_adjustments.promotion.group_by(&:label).each do |label, adjustments| %>
           <dt><%= t('spree.promotion') %></dt>
           <dd class="font-sans-md"><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></dd>
         <% end %>
@@ -50,7 +50,7 @@
     </div>
   <% end %>
 
-  <% order.adjustments.eligible.each do |adjustment| %>
+  <% order.adjustments.each do |adjustment| %>
   <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
     <div id="order-charges" class="<%= line_class_names %> font-sans-md">
       <dt><%= adjustment.label %></dt>


### PR DESCRIPTION


## Summary

With the move away from the legacy promotion system and the change where eligible is deprecated and returns all, these can now be removed. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
