### PR TITLE
Improve CI reliability and get builds passing

### DIFF
--- a/templates/spec/requests/checkouts_spec.rb
+++ b/templates/spec/requests/checkouts_spec.rb
@@ -324,7 +324,17 @@ RSpec.describe 'Checkouts', type: :request, with_signed_in_user: true do
 
       before do
         allow(Spree::OrderUpdater).to receive(:new).and_return(updater_instance)
-        allow(updater_instance).to receive(:recalculate_payment_state).and_raise(Spree::Core::GatewayError.new('Invalid something or other.'))
+
+        if Gem::Requirement.new('< 4.7').satisfied_by?(::Spree.solidus_gem_version)
+          allow(updater_instance)
+            .to receive(:update_payment_state)
+            .and_raise(Spree::Core::GatewayError.new('Invalid something or other.'))
+        else
+          allow(updater_instance)
+            .to receive(:recalculate_payment_state)
+            .and_raise(Spree::Core::GatewayError.new('Invalid something or other.'))
+        end
+
         patch update_checkout_path(state: order.state, order: { bill_address_attributes: address_params })
       end
 

--- a/templates/spec/support/solidus_starter_frontend/capybara.rb
+++ b/templates/spec/support/solidus_starter_frontend/capybara.rb
@@ -16,6 +16,9 @@ RSpec.configure do |config|
     screen_size = example.metadata[:screen_size] || [1800, 1400]
     driven_by(:selenium, using: :headless_chrome, screen_size: screen_size) do |capabilities|
       capabilities.add_argument("--disable-search-engine-choice-screen")
+      capabilities.add_preference("autofill.profile_enabled", false)
+      capabilities.add_preference("autofill.credit_card_enabled", false)
+      capabilities.add_preference('profile.password_manager_leak_detection', false)
     end
   end
 end

--- a/templates/spec/system/address_spec.rb
+++ b/templates/spec/system/address_spec.rb
@@ -21,67 +21,36 @@ RSpec.describe 'Address', type: :system do
   end
 
   context 'country requires state', js: true do
-    let!(:canada) { create(:country, name: 'Canada', states_required: true, iso: 'CA') }
-    let!(:uk) { create(:country, name: 'United Kingdom', states_required: true, iso: 'GB') }
+    let!(:has_states_country) { create(:country, name: 'Canada', states_required: true, iso: 'CA') }
+    let!(:no_states_country) { create(:country, name: 'United Kingdom', states_required: true, iso: 'GB') }
+    let!(:states_not_required_country) { create(:country, name: 'France', states_required: false, iso: 'FR') }
 
-    before { stub_spree_preferences(default_country_iso: uk.iso) }
+    before {
+      stub_spree_preferences(default_country_iso: has_states_country.iso)
 
-    context 'but has no state' do
-      it 'shows the state input field' do
-        checkout_as_guest
+      create(:state, name: 'Ontario', country: has_states_country)
+    }
 
-        within('#billing') do
-          select canada.name, from: 'Country'
-          expect(page).to have_no_css(@state_select_css)
-          expect(page).to have_css("#{@state_name_css}.required")
-        end
-      end
-    end
-
-    context 'and has state' do
-      before { create(:state, name: 'Ontario', country: canada) }
-
-      it 'shows the state collection selection' do
-        checkout_as_guest
-
-        within('#billing') do
-          select canada.name, from: 'Country'
-          expect(page).to have_no_css(@state_name_css)
-          expect(page).to have_css("#{@state_select_css}.required")
-        end
-      end
-    end
-
-    context 'user changes to country without states required' do
-      let!(:france) { create(:country, name: 'France', states_required: false, iso: 'FR') }
-
-      it 'clears the state name' do
-        checkout_as_guest
-        within('#billing') do
-          select canada.name, from: 'Country'
-
-          page.find(@state_name_css).set('Toscana')
-
-          select france.name, from: 'Country'
-        end
-
-        expect(page).to have_no_css(@state_name_css)
-        expect(page).to have_no_css(@state_select_css)
-      end
-    end
-  end
-
-  context 'country does not require state', js: true do
-    let!(:france) { create(:country, name: 'France', states_required: false, iso: 'FR') }
-
-    it 'shows a disabled state input field' do
+    scenario 'switching between countries with and without states and states required' do
       checkout_as_guest
 
       within('#billing') do
-        select france.name, from: 'Country'
+        select "United Kingdom", from: 'Country'
 
+        expect(page).to have_css("#{@state_name_css}.required")
+        expect(page).to have_no_css(@state_select_css)
+
+        page.find(@state_name_css).set('Devon')
+
+        select "Canada", from: 'Country'
+
+        expect(page).to have_css("#{@state_select_css}.required")
         expect(page).to have_no_css(@state_name_css)
+
+        select "France", from: 'Country'
+
         expect(page).to have_css("#{@state_select_css}[disabled]", visible: false)
+        expect(page).to have_no_css(@state_name_css)
       end
     end
   end

--- a/templates/spec/system/authentication/checkout_spec.rb
+++ b/templates/spec/system/authentication/checkout_spec.rb
@@ -121,11 +121,13 @@ RSpec.feature 'Checkout', :js, type: :system do
       create(:user, email: 'email@person.com', password: 'password', password_confirmation: 'password')
       click_link 'Solidus hoodie'
       click_button 'Add To Cart'
+      expect(page).to have_text 'Shopping Cart'
 
       visit login_path
       click_link 'Forgot Password?'
       fill_in 'spree_user_email', with: 'email@person.com'
       click_button 'Reset my password'
+      expect(page).to have_text('If an account with that email address exists')
 
       # Need to do this now because the token stored in the DB is the encrypted version
       # The 'plain-text' version is sent in the email and there's one way to get that!

--- a/templates/spec/system/authentication/checkout_spec.rb
+++ b/templates/spec/system/authentication/checkout_spec.rb
@@ -84,6 +84,7 @@ RSpec.feature 'Checkout', :js, type: :system do
       user = create(:user, email: 'email@person.com', password: 'password', password_confirmation: 'password')
       click_link 'Solidus hoodie'
       click_button 'Add To Cart'
+      within('h1') { expect(page).to have_text 'Shopping Cart' }
 
       visit login_path
       fill_in 'Email', with: user.email

--- a/templates/spec/system/cart_spec.rb
+++ b/templates/spec/system/cart_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Cart', type: :system do
     visit products_path
     click_link "Solidus mug set"
     click_button "add-to-cart-button"
+    expect(page).to have_text "Shopping Cart"
 
     # prevent form submit to verify button is disabled
     page.execute_script("document.getElementById('update-cart').onsubmit = function(){return false;}")
@@ -29,13 +30,16 @@ RSpec.describe 'Cart', type: :system do
 
   it 'allows you to remove an item from the cart', js: true do
     create(:product, name: "Solidus mug set")
+
     visit products_path
+
     click_link "Solidus mug set"
     click_button "add-to-cart-button"
     click_button "Remove"
+
+    expect(page).to have_content("Your cart is empty")
     expect(page).not_to have_content("Line items quantity must be an integer")
     expect(page).not_to have_content("Solidus mug set")
-    expect(page).to have_content("Your cart is empty")
 
     within "#link-to-cart" do
       expect(page.text).to eq('')
@@ -68,7 +72,7 @@ RSpec.describe 'Cart', type: :system do
       visit product_path(product)
       click_button "add-to-cart-button"
 
-      visit cart_path
+      expect(page).to have_content("Shopping Cart")
       expect(page).to have_content(product.name)
     end
   end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -173,7 +173,8 @@ RSpec.describe 'Checkout', :js, type: :system do
         before do
           add_mug_to_cart
           click_button "Checkout"
-
+          expect(page).to have_content("Login as Existing Customer")
+          
           # Simulate user login
           Spree::Order.last.associate_user!(user)
           allow_any_instance_of(CheckoutsController).to receive_messages(spree_current_user: user)
@@ -204,6 +205,7 @@ RSpec.describe 'Checkout', :js, type: :system do
           let(:saved_ship_address) { create(:address, name: 'Steve Jobs') }
 
           it 'shows empty addresses', js: true do
+
             within("#billing") do
               expect(find_field('Name').value).to eq 'Bill Gates'
             end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -713,6 +713,7 @@ RSpec.describe 'Checkout', :js, type: :system do
         fill_in "Zip", with: "H0H0H0"
 
         click_on 'Save and Continue'
+        expect(page).to have_content "We are unable to calculate shipping rates for the selected items."
         visit checkout_state_path(:address)
 
         expect(page).to have_field(state_name_css, with: xss_string)

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -661,11 +661,9 @@ RSpec.describe 'Checkout', :js, type: :system do
       click_button 'Place Order'
     end
 
-    it "displays a thank you message" do
+    it "displays a thank you message only on the first visit" do
       expect(page).to have_content(I18n.t('spree.thank_you_for_your_order'), normalize_ws: true)
-    end
 
-    it "does not display a thank you message on that order future visits" do
       visit order_path(order)
       expect(page).to_not have_content(I18n.t('spree.thank_you_for_your_order'))
     end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -593,14 +593,14 @@ RSpec.describe 'Checkout', :js, type: :system do
       Spree::Order.checkout_flow(&@old_checkout_flow)
     end
 
-    it "goes right payment step and place order just fine" do
+    it "goes right to the payment step and places the order" do
       expect(page).to have_current_path(checkout_state_path('payment'))
 
       choose "Credit Card"
       fill_in_credit_card
       click_button "Save and Continue"
+      expect(page).to have_text('Put your terms and conditions here')
 
-      expect(current_path).to eq checkout_state_path('confirm')
       check 'Agree to Terms of Service'
       click_button "Place Order"
     end

--- a/templates/spec/system/checkout_spec.rb
+++ b/templates/spec/system/checkout_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe 'Checkout', :js, type: :system do
 
         add_mug_to_cart
         click_button "Checkout"
+        expect(page).to have_content("Billing Address")
         # We need an order reload here to get newly associated addresses.
         # Then we go back to address where we are supposed to be redirected.
         order.reload


### PR DESCRIPTION
## Summary

This PR attempts to improve the test reliability of this extension and get tests passing once again, now that we're using GitHub Actions for CI.

The changes mostly involved adding assertions that the page has loaded in system specs after navigating to a new page. This was missing in a lot of test which led to unreliable specs mostly around the checkout flows.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
