### PR TITLE
Fix double render error in StoreController

### DIFF
--- a/templates/app/controllers/store_controller.rb
+++ b/templates/app/controllers/store_controller.rb
@@ -14,8 +14,9 @@ class StoreController < Spree::BaseController
   end
 
   def cart_link
-    render partial: 'shared/cart/link_to_cart'
-    fresh_when(etag: current_order, template: 'shared/cart/_link_to_cart')
+    unless fresh_when(etag: current_order, template: 'shared/cart/_link_to_cart')
+      render partial: 'shared/cart/link_to_cart'
+    end
   end
 
   private


### PR DESCRIPTION
## Summary

It seems like the way this method works changed in Rails 8 and we no longer
need to render when using `fresh_when`, as it will either render the partial or
return a not modified status code. The previous behaviour would result in a double
render error on new versions of Rails.

Fixes #444

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
